### PR TITLE
chore: editorconfig와 prettier eol

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# Editor configuration, see http://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+max_line_length = off
+trim_trailing_whitespace = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -3,6 +3,7 @@ root = true
 
 [*]
 charset = utf-8
+end_of_line = lf
 indent_style = space
 indent_size = 2
 insert_final_newline = true

--- a/libs/shared/utils-eslint-config/.eslintrc.js
+++ b/libs/shared/utils-eslint-config/.eslintrc.js
@@ -17,7 +17,7 @@ module.exports = {
         singleQuote: true,
         printWidth: 120,
         arrowParens: 'avoid',
-        endOfLine: 'auto',
+        endOfLine: 'lf',
       },
     ],
     'import/extensions': ['off'],


### PR DESCRIPTION
킹도우에서 autocrlf 이슈로 crlf를 사용하게 되는 문제를 해결하기 위한 수정입니다.

- editorconfig 설정 (webstorm 기본 지원, vscode 플긴 깔면 지원)
- prettier eol `lf`로 고정