### PR TITLE
fix: images.domains를 remotePatterns로 변경

### DIFF
--- a/apps/service-web/next.config.js
+++ b/apps/service-web/next.config.js
@@ -5,9 +5,17 @@ const { withKumaUI } = require('@kuma-ui/next-plugin');
 const nextConfig = {
   compiler: {},
   images: {
-    domains: [
-      'res.cloudinary.com',
-      'via.placeholder.com', // memo(@ddarkr): 개발 목적의 이미지 도메인 등록
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'res.cloudinary.com',
+        port: '',
+      },
+      {
+        protocol: 'https',
+        hostname: 'via.placeholder.com',
+        port: '',
+      },
     ],
   },
 };


### PR DESCRIPTION
```
⚠ The "images.domains" configuration is deprecated. Please use "images.remotePatterns" configuration instead.
```

Next.js 14부터 images.domains이 deprecated되서 변경했습니다.

https://nextjs.org/docs/pages/api-reference/components/image#remotepatterns