### PR TITLE
feat: add product link editing

### DIFF
--- a/apps/graphql-api/schema.graphql
+++ b/apps/graphql-api/schema.graphql
@@ -182,8 +182,8 @@ type Mutation {
   registerProductCompany(input: RegisterProductCompanyInput!, slug: String!): RegisterProductCompanyPayload!
   signImageUpload(input: SignImageUploadInput!): SignImageUploadPayload!
   updateAlternativeProduct(input: UpdateAlternativeProductInput!, slug: String!): UpdateAlternativeProductPayload!
-  updateProductLink(id: String!, input: UpdateProductLinkInput!, slug: String!): UpdateProductLinkPayload!
   updateProductFeature(id: String!, input: UpdateProductFeatureInput!): UpdateProductFeaturePayload!
+  updateProductLink(id: String!, input: UpdateProductLinkInput!, slug: String!): UpdateProductLinkPayload!
   updateProductTags(input: UpdateProductTagsInput!, slug: String!): UpdateProductTagsPayload!
   upvoteProduct(slug: String!): UpvoteProductPayload!
 }
@@ -297,6 +297,16 @@ type UpdateAlternativeProductPayload {
   product: Product
 }
 
+input UpdateProductFeatureInput {
+  emoji: String
+  name: String
+  summary: String
+}
+
+type UpdateProductFeaturePayload {
+  feature: Feature!
+}
+
 input UpdateProductLinkInput {
   displayLink: String
   iconUrl: String
@@ -306,16 +316,6 @@ input UpdateProductLinkInput {
 
 type UpdateProductLinkPayload {
   product: Product
-}
-
-input UpdateProductFeatureInput {
-  emoji: String
-  name: String
-  summary: String
-}
-
-type UpdateProductFeaturePayload {
-  feature: Feature!
 }
 
 input UpdateProductTagsInput {

--- a/apps/graphql-api/schema.graphql
+++ b/apps/graphql-api/schema.graphql
@@ -182,6 +182,7 @@ type Mutation {
   registerProductCompany(input: RegisterProductCompanyInput!, slug: String!): RegisterProductCompanyPayload!
   signImageUpload(input: SignImageUploadInput!): SignImageUploadPayload!
   updateAlternativeProduct(input: UpdateAlternativeProductInput!, slug: String!): UpdateAlternativeProductPayload!
+  updateProductLink(id: String!, input: UpdateProductLinkInput!, slug: String!): UpdateProductLinkPayload!
   updateProductFeature(id: String!, input: UpdateProductFeatureInput!): UpdateProductFeaturePayload!
   updateProductTags(input: UpdateProductTagsInput!, slug: String!): UpdateProductTagsPayload!
   upvoteProduct(slug: String!): UpvoteProductPayload!
@@ -293,6 +294,17 @@ input UpdateAlternativeProductInput {
 }
 
 type UpdateAlternativeProductPayload {
+  product: Product
+}
+
+input UpdateProductLinkInput {
+  displayLink: String
+  iconUrl: String
+  link: String
+  title: String
+}
+
+type UpdateProductLinkPayload {
   product: Product
 }
 

--- a/apps/graphql-api/src/app/graphql/product/Product.mutation.resolver.ts
+++ b/apps/graphql-api/src/app/graphql/product/Product.mutation.resolver.ts
@@ -6,6 +6,7 @@ import {
   GetPublishedProduct,
   IndexProduct,
   AddProductLink,
+  UpdateProductLink,
   PublishProduct,
   UpdateAlternativeProduct,
   EditProduct,
@@ -25,6 +26,7 @@ import { Product } from './graphs/Product';
 import { PublishProductInput, PublishProductPayload } from './graphs/PublishProduct';
 import { RegisterProductCompanyInput, RegisterProductCompanyPayload } from './graphs/RegisterProductCompany';
 import { UpdateAlternativeProductInput, UpdateAlternativeProductPayload } from './graphs/UpdateAlternativeProduct';
+import { UpdateProductLinkInput, UpdateProductLinkPayload } from './graphs/UpdateProductLink';
 import { UpdateProductTagsInput, UpdateProductTagsPayload } from './graphs/UpdateProductTags';
 import { UpvoteProductPayload } from './graphs/UpvoteProduct';
 
@@ -42,6 +44,7 @@ export class ProductMutationResolver {
     private readonly getProductUseCase: GetProduct,
     private readonly addProductScreenshotUseCase: AddProductScreenshot,
     private readonly addProductLinkUseCase: AddProductLink,
+    private readonly updateProductLinkUseCase: UpdateProductLink,
     private readonly updateAlternativeProductUseCase: UpdateAlternativeProduct,
     private readonly upvoteProductUseCase: UpvoteProduct,
     private readonly registerProductCompanyUseCase: RegisterProductCompany
@@ -177,6 +180,26 @@ export class ProductMutationResolver {
     }
 
     await this.addProductLinkUseCase.execute({ ...input, productId: product.id });
+
+    return {
+      product: await this.getProductUseCase.execute({ slug }),
+    };
+  }
+
+  @Authorized([AuthRole.Admin])
+  @Mutation(() => UpdateProductLinkPayload)
+  async updateProductLink(
+    @Arg('slug') slug: string,
+    @Arg('id') id: string,
+    @Arg('input') input: UpdateProductLinkInput
+  ): Promise<UpdateProductLinkPayload> {
+    const product = await this.getProductUseCase.execute({ slug });
+
+    if (!product) {
+      throw new Error('Product not found');
+    }
+
+    await this.updateProductLinkUseCase.execute({ linkId: id, ...input });
 
     return {
       product: await this.getProductUseCase.execute({ slug }),

--- a/apps/graphql-api/src/app/graphql/product/graphs/UpdateProductLink.ts
+++ b/apps/graphql-api/src/app/graphql/product/graphs/UpdateProductLink.ts
@@ -1,0 +1,23 @@
+import { Field, InputType, ObjectType } from 'type-graphql';
+import { Product } from './Product';
+
+@ObjectType()
+export class UpdateProductLinkPayload {
+  @Field(() => Product, { nullable: true })
+  product: Product | null;
+}
+
+@InputType()
+export class UpdateProductLinkInput {
+  @Field({ nullable: true })
+  title?: string;
+
+  @Field({ nullable: true })
+  link?: string;
+
+  @Field({ nullable: true })
+  displayLink?: string;
+
+  @Field({ nullable: true })
+  iconUrl?: string;
+}

--- a/libs/admin/src/libs/products/components/EditProductLinkItem/EditProductLinkItem.tsx
+++ b/libs/admin/src/libs/products/components/EditProductLinkItem/EditProductLinkItem.tsx
@@ -1,0 +1,81 @@
+import { bind } from '@croco/utils-structure-react';
+import { Button, Group, Select, SelectProps, Stack, TextInput } from '@mantine/core';
+import { IconCheck } from '@tabler/icons-react';
+import { useEditProductLinkItem } from './useEditProductLinkItem';
+
+export const EditProductLinkItem = bind(useEditProductLinkItem, ({ form, submit, loading }) => {
+  return (
+    <form onSubmit={form.onSubmit(submit)}>
+      <Stack>
+        <TextInput
+          name="displayLink"
+          size="md"
+          label="표시 링크"
+          placeholder={'ex) toss.im'}
+          key={form.key('displayLink')}
+          {...form.getInputProps('displayLink')}
+        />
+        <TextInput
+          name="link"
+          size="md"
+          label="링크"
+          placeholder={'ex) https://toss.im/'}
+          key={form.key('link')}
+          {...form.getInputProps('link')}
+        />
+        <TextInput
+          name="title"
+          size="md"
+          label="이름"
+          placeholder={'ex) 공식 홈페이지'}
+          key={form.key('title')}
+          {...form.getInputProps('title')}
+        />
+        <Select
+          name="iconUrl"
+          size="md"
+          label="링크"
+          placeholder={
+            'ex) https://res.cloudinary.com/dqddtkvmb/image/upload/v1709304777/images/icons/links/pvjgv9btsktstjkoarrl.svg'
+          }
+          data={iconData}
+          renderOption={renderSelectOption}
+          key={form.key('iconUrl')}
+          {...form.getInputProps('iconUrl')}
+        />
+        <Group justify="flex-end" mt="md">
+          <Button type="submit" color={'dark'} disabled={loading}>
+            저장
+          </Button>
+        </Group>
+      </Stack>
+    </form>
+  );
+});
+
+const iconData = [
+  {
+    value: 'https://res.cloudinary.com/dqddtkvmb/image/upload/v1709304777/images/icons/links/pvjgv9btsktstjkoarrl.svg',
+    label: '지구본 아이콘 (흰색) (주 링크 용도)',
+  },
+  {
+    value: 'https://res.cloudinary.com/dqddtkvmb/image/upload/v1709304777/images/icons/links/hdo1rx06frvuhf5q0gio.svg',
+    label: '인스타그램 (그레이)',
+  },
+  {
+    value: 'https://res.cloudinary.com/dqddtkvmb/image/upload/v1709304777/images/icons/links/i9ea1d250oskdzvu7iby.svg',
+    label: 'X(Twitter) (그레이)',
+  },
+  {
+    value: 'https://res.cloudinary.com/dqddtkvmb/image/upload/v1709304776/images/icons/links/kiezpv3buqv7w8xajhw4.svg',
+    label: 'GitHub (검정)',
+  },
+];
+
+const renderSelectOption: SelectProps['renderOption'] = ({ option, checked }) => (
+  <Group flex="1" gap="xs">
+    <img src={option.value} style={{ width: 20, height: 20 }} />
+    {option.label}
+    {checked && <IconCheck style={{ marginInlineStart: 'auto' }} />}
+  </Group>
+);

--- a/libs/admin/src/libs/products/components/EditProductLinkItem/__generated__/useEditProductLinkItem.ts
+++ b/libs/admin/src/libs/products/components/EditProductLinkItem/__generated__/useEditProductLinkItem.ts
@@ -1,0 +1,54 @@
+import * as Types from '@darun/provider-graphql';
+
+import { gql } from '@apollo/client';
+import { ProductLinkTableFragmentDoc } from '../../ProductLinkTable/__generated__/ProductLinkTable';
+import * as Apollo from '@apollo/client';
+const defaultOptions = {} as const;
+export type UpdateProductLinkOnEditProductLinkItemMutationVariables = Types.Exact<{
+  slug: Types.Scalars['String']['input'];
+  id: Types.Scalars['String']['input'];
+  input: Types.UpdateProductLinkInput;
+}>;
+
+
+export type UpdateProductLinkOnEditProductLinkItemMutation = { __typename?: 'Mutation', updateProductLink: { __typename?: 'UpdateProductLinkPayload', product?: { __typename?: 'Product', id: string, links: Array<{ __typename?: 'Link', id: string, title: string, link: string, displayLink: string, iconUrl: string, isPrimary: boolean }> } | null } };
+
+
+export const UpdateProductLinkOnEditProductLinkItemDocument = gql`
+    mutation UpdateProductLinkOnEditProductLinkItem($slug: String!, $id: String!, $input: UpdateProductLinkInput!) {
+  updateProductLink(slug: $slug, id: $id, input: $input) {
+    product {
+      id
+      ...ProductLinkTable
+    }
+  }
+}
+    ${ProductLinkTableFragmentDoc}`;
+export type UpdateProductLinkOnEditProductLinkItemMutationFn = Apollo.MutationFunction<UpdateProductLinkOnEditProductLinkItemMutation, UpdateProductLinkOnEditProductLinkItemMutationVariables>;
+
+/**
+ * __useUpdateProductLinkOnEditProductLinkItemMutation__
+ *
+ * To run a mutation, you first call `useUpdateProductLinkOnEditProductLinkItemMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUpdateProductLinkOnEditProductLinkItemMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [updateProductLinkOnEditProductLinkItemMutation, { data, loading, error }] = useUpdateProductLinkOnEditProductLinkItemMutation({
+ *   variables: {
+ *      slug: // value for 'slug'
+ *      id: // value for 'id'
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useUpdateProductLinkOnEditProductLinkItemMutation(baseOptions?: Apollo.MutationHookOptions<UpdateProductLinkOnEditProductLinkItemMutation, UpdateProductLinkOnEditProductLinkItemMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateProductLinkOnEditProductLinkItemMutation, UpdateProductLinkOnEditProductLinkItemMutationVariables>(UpdateProductLinkOnEditProductLinkItemDocument, options);
+      }
+export type UpdateProductLinkOnEditProductLinkItemMutationHookResult = ReturnType<typeof useUpdateProductLinkOnEditProductLinkItemMutation>;
+export type UpdateProductLinkOnEditProductLinkItemMutationResult = Apollo.MutationResult<UpdateProductLinkOnEditProductLinkItemMutation>;
+export type UpdateProductLinkOnEditProductLinkItemMutationOptions = Apollo.BaseMutationOptions<UpdateProductLinkOnEditProductLinkItemMutation, UpdateProductLinkOnEditProductLinkItemMutationVariables>;

--- a/libs/admin/src/libs/products/components/EditProductLinkItem/index.ts
+++ b/libs/admin/src/libs/products/components/EditProductLinkItem/index.ts
@@ -1,0 +1,1 @@
+export { EditProductLinkItem } from './EditProductLinkItem';

--- a/libs/admin/src/libs/products/components/EditProductLinkItem/useEditProductLinkItem.ts
+++ b/libs/admin/src/libs/products/components/EditProductLinkItem/useEditProductLinkItem.ts
@@ -1,16 +1,20 @@
-import { gql, useMutation } from '@apollo/client';
+import { gql } from '@apollo/client';
 import { useForm } from '@mantine/form';
 import { notifications } from '@mantine/notifications';
-import { TempProductBySlugOnProductLinkTableDocument } from '../ProductLinkTable/__generated__/useProductLinkTable';
+import { ProductLinkTableFragmentDoc } from '../ProductLinkTable/__generated__/ProductLinkTable';
+import { useUpdateProductLinkOnEditProductLinkItemMutation } from './__generated__/useEditProductLinkItem';
 
-const UPDATE_PRODUCT_LINK_MUTATION = gql`
+gql`
   mutation UpdateProductLinkOnEditProductLinkItem($slug: String!, $id: String!, $input: UpdateProductLinkInput!) {
     updateProductLink(slug: $slug, id: $id, input: $input) {
       product {
         id
+        ...ProductLinkTable
       }
     }
   }
+
+  ${ProductLinkTableFragmentDoc}
 `;
 
 type EditProductLinkItemProps = {
@@ -33,7 +37,7 @@ type FormValues = {
 };
 
 export function useEditProductLinkItem({ slug, link, onSubmit }: EditProductLinkItemProps) {
-  const [updateLink, { loading }] = useMutation(UPDATE_PRODUCT_LINK_MUTATION);
+  const [updateLink, { loading }] = useUpdateProductLinkOnEditProductLinkItemMutation();
 
   const form = useForm<FormValues>({
     mode: 'uncontrolled',
@@ -62,7 +66,6 @@ export function useEditProductLinkItem({ slug, link, onSubmit }: EditProductLink
           iconUrl: values.iconUrl,
         },
       },
-      refetchQueries: [{ query: TempProductBySlugOnProductLinkTableDocument, variables: { slug } }],
     });
 
     notifications.show({ message: '수정되었습니다.', color: 'teal' });

--- a/libs/admin/src/libs/products/components/EditProductLinkItem/useEditProductLinkItem.ts
+++ b/libs/admin/src/libs/products/components/EditProductLinkItem/useEditProductLinkItem.ts
@@ -1,0 +1,75 @@
+import { gql, useMutation } from '@apollo/client';
+import { useForm } from '@mantine/form';
+import { notifications } from '@mantine/notifications';
+import { TempProductBySlugOnProductLinkTableDocument } from '../ProductLinkTable/__generated__/useProductLinkTable';
+
+const UPDATE_PRODUCT_LINK_MUTATION = gql`
+  mutation UpdateProductLinkOnEditProductLinkItem($slug: String!, $id: String!, $input: UpdateProductLinkInput!) {
+    updateProductLink(slug: $slug, id: $id, input: $input) {
+      product {
+        id
+      }
+    }
+  }
+`;
+
+type EditProductLinkItemProps = {
+  slug: string;
+  link: {
+    id: string;
+    title: string;
+    link: string;
+    displayLink: string;
+    iconUrl: string;
+  };
+  onSubmit?: () => void;
+};
+
+type FormValues = {
+  title?: string;
+  link?: string;
+  displayLink?: string;
+  iconUrl?: string;
+};
+
+export function useEditProductLinkItem({ slug, link, onSubmit }: EditProductLinkItemProps) {
+  const [updateLink, { loading }] = useMutation(UPDATE_PRODUCT_LINK_MUTATION);
+
+  const form = useForm<FormValues>({
+    mode: 'uncontrolled',
+    initialValues: {
+      title: link.title,
+      link: link.link,
+      displayLink: link.displayLink,
+      iconUrl: link.iconUrl,
+    },
+  });
+
+  const submit = async (values: FormValues) => {
+    if (!values.title && !values.link && !values.displayLink && !values.iconUrl) {
+      notifications.show({ message: '모든 값이 비어있을 수는 없습니다.', color: 'red' });
+      return;
+    }
+
+    await updateLink({
+      variables: {
+        slug,
+        id: link.id,
+        input: {
+          title: values.title,
+          link: values.link,
+          displayLink: values.displayLink,
+          iconUrl: values.iconUrl,
+        },
+      },
+      refetchQueries: [{ query: TempProductBySlugOnProductLinkTableDocument, variables: { slug } }],
+    });
+
+    notifications.show({ message: '수정되었습니다.', color: 'teal' });
+    if (onSubmit) {
+      onSubmit();
+    }
+  };
+
+  return { form, submit, loading };
+}

--- a/libs/admin/src/libs/products/components/ProductLinkTable/ProductLinkTable.tsx
+++ b/libs/admin/src/libs/products/components/ProductLinkTable/ProductLinkTable.tsx
@@ -1,8 +1,22 @@
+import { gql } from '@apollo/client';
 import { bind } from '@croco/utils-structure-react';
 import { Button, Group, rem, Table, Text } from '@mantine/core';
 import { IconPencil } from '@tabler/icons-react';
 import styles from './ProductFeatureTable.module.css';
 import { useProductLinkTable } from './useProductLinkTable';
+
+gql`
+  fragment ProductLinkTable on Product {
+    links {
+      id
+      title
+      link
+      displayLink
+      iconUrl
+      isPrimary
+    }
+  }
+`;
 
 export const ProductLinkTable = bind(useProductLinkTable, ({ links, loading, editLink }) => {
   if (loading) {

--- a/libs/admin/src/libs/products/components/ProductLinkTable/ProductLinkTable.tsx
+++ b/libs/admin/src/libs/products/components/ProductLinkTable/ProductLinkTable.tsx
@@ -4,7 +4,7 @@ import { IconPencil } from '@tabler/icons-react';
 import styles from './ProductFeatureTable.module.css';
 import { useProductLinkTable } from './useProductLinkTable';
 
-export const ProductLinkTable = bind(useProductLinkTable, ({ links, loading }) => {
+export const ProductLinkTable = bind(useProductLinkTable, ({ links, loading, editLink }) => {
   if (loading) {
     return <>로딩 중...</>;
   }
@@ -65,9 +65,9 @@ export const ProductLinkTable = bind(useProductLinkTable, ({ links, loading }) =
                     leftSection={<IconPencil style={{ width: rem(16), height: rem(16) }} stroke={1.5} />}
                     variant="default"
                     size={'compact-xs'}
-                    disabled
+                    onClick={() => editLink(link)}
                   >
-                    정보 수정 (준비중)
+                    정보 수정
                   </Button>
                 </Group>
               </Table.Td>

--- a/libs/admin/src/libs/products/components/ProductLinkTable/__generated__/ProductLinkTable.ts
+++ b/libs/admin/src/libs/products/components/ProductLinkTable/__generated__/ProductLinkTable.ts
@@ -1,0 +1,17 @@
+import * as Types from '@darun/provider-graphql';
+
+import { gql } from '@apollo/client';
+export type ProductLinkTableFragment = { __typename?: 'Product', links: Array<{ __typename?: 'Link', id: string, title: string, link: string, displayLink: string, iconUrl: string, isPrimary: boolean }> };
+
+export const ProductLinkTableFragmentDoc = gql`
+    fragment ProductLinkTable on Product {
+  links {
+    id
+    title
+    link
+    displayLink
+    iconUrl
+    isPrimary
+  }
+}
+    `;

--- a/libs/admin/src/libs/products/components/ProductLinkTable/__generated__/useProductLinkTable.ts
+++ b/libs/admin/src/libs/products/components/ProductLinkTable/__generated__/useProductLinkTable.ts
@@ -1,6 +1,7 @@
 import * as Types from '@darun/provider-graphql';
 
 import { gql } from '@apollo/client';
+import { ProductLinkTableFragmentDoc } from './ProductLinkTable';
 import * as Apollo from '@apollo/client';
 const defaultOptions = {} as const;
 export type TempProductBySlugOnProductLinkTableQueryVariables = Types.Exact<{
@@ -15,17 +16,10 @@ export const TempProductBySlugOnProductLinkTableDocument = gql`
     query TempProductBySlugOnProductLinkTable($slug: String!) {
   tempProductBySlug(slug: $slug) {
     id
-    links {
-      id
-      title
-      link
-      displayLink
-      iconUrl
-      isPrimary
-    }
+    ...ProductLinkTable
   }
 }
-    `;
+    ${ProductLinkTableFragmentDoc}`;
 
 /**
  * __useTempProductBySlugOnProductLinkTableQuery__

--- a/libs/admin/src/libs/products/components/ProductLinkTable/useProductLinkTable.ts
+++ b/libs/admin/src/libs/products/components/ProductLinkTable/useProductLinkTable.ts
@@ -1,20 +1,16 @@
 import { gql } from '@apollo/client';
+import { ProductLinkTableFragmentDoc } from './__generated__/ProductLinkTable';
 import { useTempProductBySlugOnProductLinkTableQuery } from './__generated__/useProductLinkTable';
 
 gql`
   query TempProductBySlugOnProductLinkTable($slug: String!) {
     tempProductBySlug(slug: $slug) {
       id
-      links {
-        id
-        title
-        link
-        displayLink
-        iconUrl
-        isPrimary
-      }
+      ...ProductLinkTable
     }
   }
+
+  ${ProductLinkTableFragmentDoc}
 `;
 
 type ProductLinkTableProps = {

--- a/libs/admin/src/libs/products/components/ProductLinkTable/useProductLinkTable.ts
+++ b/libs/admin/src/libs/products/components/ProductLinkTable/useProductLinkTable.ts
@@ -19,9 +19,17 @@ gql`
 
 type ProductLinkTableProps = {
   slug: string;
+  editLink: (link: {
+    id: string;
+    title: string;
+    link: string;
+    displayLink: string;
+    iconUrl: string;
+    isPrimary?: boolean;
+  }) => void;
 };
 
-export function useProductLinkTable({ slug }: ProductLinkTableProps) {
+export function useProductLinkTable({ slug, editLink }: ProductLinkTableProps) {
   const { data, loading } = useTempProductBySlugOnProductLinkTableQuery({ variables: { slug } });
-  return { links: data?.tempProductBySlug?.links, loading };
+  return { links: data?.tempProductBySlug?.links, loading, editLink };
 }

--- a/libs/admin/src/libs/products/shells/ProductDetailLinkSection/ProductDetailLinkSection.tsx
+++ b/libs/admin/src/libs/products/shells/ProductDetailLinkSection/ProductDetailLinkSection.tsx
@@ -1,28 +1,35 @@
 import { bind } from '@croco/utils-structure-react';
-import { Button, Card, Group, Stack, Title, Text } from '@mantine/core';
+import { Button, Card, Group, Modal, Stack, Title, Text } from '@mantine/core';
 import Link from 'next/link';
 import { ProductLinkTable } from '../../components/ProductLinkTable';
 import { useProductDetailLinkSection } from './useProductDetailLinkSection';
+import { EditProductLinkItem } from '../../components/EditProductLinkItem';
 
-export const ProductDetailLinkSection = bind(useProductDetailLinkSection, ({ slug }) => (
-  <>
-    <Stack gap={8}>
-      <Group justify={'space-between'}>
-        <Stack gap={0}>
-          <Title order={3}>링크 관리</Title>
-          <Text c="dimmed" fw={500} size="sm">
-            서비스 정보에서 목차 위에 표시되는 링크 버튼에 뜨는 버튼들을 관리합니다.
-          </Text>
-        </Stack>
-        <Link href={`/products/${slug}/links/new`}>
-          <Button color={'dark'}>새 링크 추가 (아직 수정 기능 없으니 신중히 추가해주세요)</Button>
-        </Link>
-      </Group>
-      <Card withBorder shadow="sm" radius="md">
-        <Card.Section withBorder inheritPadding py="xs">
-          <ProductLinkTable slug={slug} />
-        </Card.Section>
-      </Card>
-    </Stack>
-  </>
-));
+export const ProductDetailLinkSection = bind(
+  useProductDetailLinkSection,
+  ({ slug, isEditModalOpened, closeEditModal, editLink, link }) => (
+    <>
+      <Stack gap={8}>
+        <Group justify={'space-between'}>
+          <Stack gap={0}>
+            <Title order={3}>링크 관리</Title>
+            <Text c="dimmed" fw={500} size="sm">
+              서비스 정보에서 목차 위에 표시되는 링크 버튼에 뜨는 버튼들을 관리합니다.
+            </Text>
+          </Stack>
+          <Link href={`/products/${slug}/links/new`}>
+            <Button color={'dark'}>새 링크 추가</Button>
+          </Link>
+        </Group>
+        <Card withBorder shadow="sm" radius="md">
+          <Card.Section withBorder inheritPadding py="xs">
+            <ProductLinkTable slug={slug} editLink={editLink} />
+          </Card.Section>
+        </Card>
+      </Stack>
+      <Modal opened={isEditModalOpened} onClose={closeEditModal} title="링크 정보 수정" centered>
+        {link ? <EditProductLinkItem slug={slug} link={link} onSubmit={closeEditModal} /> : <>오류 발생. 새로고침 후 시도.</>}
+      </Modal>
+    </>
+  )
+);

--- a/libs/admin/src/libs/products/shells/ProductDetailLinkSection/useProductDetailLinkSection.ts
+++ b/libs/admin/src/libs/products/shells/ProductDetailLinkSection/useProductDetailLinkSection.ts
@@ -1,7 +1,27 @@
+import { useDisclosure } from '@mantine/hooks';
+import { useCallback, useState } from 'react';
+
 type ProductDetailLinkSectionProps = {
   slug: string;
 };
 
 export function useProductDetailLinkSection({ slug }: ProductDetailLinkSectionProps) {
-  return { slug };
+  const [isEditModalOpened, { open: openEditModal, close: closeEditModal }] = useDisclosure(false);
+  const [link, setLink] = useState<{
+    id: string;
+    title: string;
+    link: string;
+    displayLink: string;
+    iconUrl: string;
+  }>();
+
+  const editLink = useCallback(
+    (selectedLink: { id: string; title: string; link: string; displayLink: string; iconUrl: string }) => {
+      setLink(selectedLink);
+      openEditModal();
+    },
+    [openEditModal]
+  );
+
+  return { slug, isEditModalOpened, closeEditModal, editLink, link };
 }

--- a/libs/backend/src/index.ts
+++ b/libs/backend/src/index.ts
@@ -16,6 +16,7 @@ export {
   CreateProductFeature,
   AddProductScreenshot,
   AddProductLink,
+  UpdateProductLink,
   PublishProduct,
   EditProduct,
   RegisterProductCompany,

--- a/libs/backend/src/libs/products/datasource/repositories/PostgresqlProductLinkRepository.ts
+++ b/libs/backend/src/libs/products/datasource/repositories/PostgresqlProductLinkRepository.ts
@@ -1,7 +1,7 @@
 import { Drizzle, DrizzleToken } from '@darun/provider-database';
 import { ProductLink, ProductLinkRepository, ProductLinkRepositoryToken } from '@products/domain';
 import DataLoader from 'dataloader';
-import { inArray } from 'drizzle-orm';
+import { eq, inArray } from 'drizzle-orm';
 import { groupBy } from 'es-toolkit';
 import { Inject, Service } from 'typedi';
 import { productLinks } from '../entities/ProductLinksSchema';
@@ -10,14 +10,17 @@ import { productLinks } from '../entities/ProductLinksSchema';
 export class PostgresqlProductLinkRepository implements ProductLinkRepository {
   private productIdLoader: DataLoader<string, ProductLink[]>;
   constructor(@Inject(DrizzleToken) private readonly db: Drizzle) {
-    this.productIdLoader = new DataLoader(
+    this.productIdLoader = new DataLoader<string, ProductLink[]>(
       async (productIds: readonly string[]) => {
         const docs = await this.db
           .select()
           .from(productLinks)
           .where(inArray(productLinks.productId, [...productIds]));
 
-        const groupByDocs = groupBy(docs, doc => doc.productId);
+        const groupByDocs = groupBy(
+          docs.map(doc => this.mapper(doc)),
+          doc => doc.productId
+        );
         return productIds.map(productId => groupByDocs[productId] || []);
       },
       {
@@ -33,11 +36,44 @@ export class PostgresqlProductLinkRepository implements ProductLinkRepository {
       if (!inserted[0]) {
         throw new Error('Failed to insert product screenshot');
       }
-      return inserted[0];
+      return this.mapper(inserted[0]);
     });
   }
 
   async findManyByProductId(productId: string): Promise<ProductLink[]> {
     return this.productIdLoader.load(productId);
+  }
+
+  updateById(linkId: string, modifier: (link: ProductLink) => ProductLink): Promise<ProductLink> {
+    return this.db.transaction(async tx => {
+      const prevLink = await tx
+        .select()
+        .from(productLinks)
+        .where(eq(productLinks.id, linkId))
+        .limit(1)
+        .then(rows => (rows[0] ? this.mapper(rows[0]) : null));
+
+      if (!prevLink) {
+        throw new Error('ProductLink not found');
+      }
+
+      const updated = await tx
+        .update(productLinks)
+        .set({ ...modifier(prevLink) })
+        .where(eq(productLinks.id, linkId))
+        .returning();
+
+      if (!updated[0]) {
+        throw new Error('ProductLink update failed');
+      }
+
+      return this.mapper(updated[0]);
+    });
+  }
+
+  private mapper(schema: typeof productLinks.$inferSelect | typeof productLinks.$inferInsert): ProductLink {
+    return new ProductLink({
+      ...schema,
+    });
   }
 }

--- a/libs/backend/src/libs/products/domain/entities/ProductLink.ts
+++ b/libs/backend/src/libs/products/domain/entities/ProductLink.ts
@@ -31,4 +31,29 @@ export class ProductLink {
       this.id = id;
     }
   }
+
+  public update({
+    title,
+    link,
+    displayLink,
+    iconUrl,
+  }: {
+    title?: string;
+    link?: string;
+    displayLink?: string;
+    iconUrl?: string;
+  }) {
+    if (title) {
+      this.title = title;
+    }
+    if (link) {
+      this.link = link;
+    }
+    if (displayLink) {
+      this.displayLink = displayLink;
+    }
+    if (iconUrl) {
+      this.iconUrl = iconUrl;
+    }
+  }
 }

--- a/libs/backend/src/libs/products/domain/index.ts
+++ b/libs/backend/src/libs/products/domain/index.ts
@@ -36,6 +36,7 @@ export { UpdateProductFeature } from './usecases/UpdateProductFeature';
 export { CreateProductFeature } from './usecases/CreateProductFeature';
 export { AddProductScreenshot } from './usecases/AddProductScreenshot';
 export { AddProductLink } from './usecases/AddProductLink';
+export { UpdateProductLink } from './usecases/UpdateProductLink';
 export { PublishProduct } from './usecases/PublishProduct';
 export { EditProduct } from './usecases/EditProduct';
 export { RegisterProductCompany } from './usecases/RegisterProductCompany';

--- a/libs/backend/src/libs/products/domain/repositories/ProductLinkRepository.ts
+++ b/libs/backend/src/libs/products/domain/repositories/ProductLinkRepository.ts
@@ -4,6 +4,7 @@ import { ProductLink } from '../entities/ProductLink';
 export interface ProductLinkRepository {
   insert(input: ProductLink): Promise<ProductLink>;
   findManyByProductId(productId: string): Promise<ProductLink[]>;
+  updateById(linkId: string, modifier: (link: ProductLink) => ProductLink): Promise<ProductLink>;
 }
 
 export const ProductLinkRepositoryToken = new Token<ProductLinkRepository>('ProductLinkRepository');

--- a/libs/backend/src/libs/products/domain/usecases/UpdateProductLink.ts
+++ b/libs/backend/src/libs/products/domain/usecases/UpdateProductLink.ts
@@ -1,0 +1,29 @@
+import { Inject, Service } from 'typedi';
+import { ProductLink } from '../entities/ProductLink';
+import { ProductLinkRepository, ProductLinkRepositoryToken } from '../repositories/ProductLinkRepository';
+
+@Service()
+export class UpdateProductLink {
+  constructor(
+    @Inject(ProductLinkRepositoryToken) private readonly productLinkRepository: ProductLinkRepository
+  ) {}
+
+  async execute({
+    linkId,
+    title,
+    link,
+    displayLink,
+    iconUrl,
+  }: {
+    linkId: string;
+    title?: string;
+    link?: string;
+    displayLink?: string;
+    iconUrl?: string;
+  }): Promise<ProductLink> {
+    return this.productLinkRepository.updateById(linkId, productLink => {
+      productLink.update({ title, link, displayLink, iconUrl });
+      return productLink;
+    });
+  }
+}

--- a/libs/shared/provider-graphql/src/index.ts
+++ b/libs/shared/provider-graphql/src/index.ts
@@ -209,6 +209,7 @@ export type Mutation = {
   readonly signImageUpload: SignImageUploadPayload;
   readonly updateAlternativeProduct: UpdateAlternativeProductPayload;
   readonly updateProductFeature: UpdateProductFeaturePayload;
+  readonly updateProductLink: UpdateProductLinkPayload;
   readonly updateProductTags: UpdateProductTagsPayload;
   readonly upvoteProduct: UpvoteProductPayload;
 };
@@ -293,6 +294,13 @@ export type MutationupdateAlternativeProductArgs = {
 export type MutationupdateProductFeatureArgs = {
   id: Scalars['String']['input'];
   input: UpdateProductFeatureInput;
+};
+
+
+export type MutationupdateProductLinkArgs = {
+  id: Scalars['String']['input'];
+  input: UpdateProductLinkInput;
+  slug: Scalars['String']['input'];
 };
 
 
@@ -499,6 +507,18 @@ export type UpdateProductFeatureInput = {
 export type UpdateProductFeaturePayload = {
   readonly __typename?: 'UpdateProductFeaturePayload';
   readonly feature: Feature;
+};
+
+export type UpdateProductLinkInput = {
+  readonly displayLink?: InputMaybe<Scalars['String']['input']>;
+  readonly iconUrl?: InputMaybe<Scalars['String']['input']>;
+  readonly link?: InputMaybe<Scalars['String']['input']>;
+  readonly title?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type UpdateProductLinkPayload = {
+  readonly __typename?: 'UpdateProductLinkPayload';
+  readonly product?: Maybe<Product>;
 };
 
 export type UpdateProductTagsInput = {

--- a/turbo.json
+++ b/turbo.json
@@ -6,6 +6,10 @@
       "dependsOn": ["^build", "prepare"],
       "outputs": [".next/**", "!.next/cache/**"]
     },
+    "codegen": {
+      "cache": false,
+      "dependsOn": ["^codegen"]
+    },
     "dev": {
       "cache": false,
       "dependsOn": ["prepare"],


### PR DESCRIPTION
## Summary
- allow updating product links via new mutation
- enable link editing in admin

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck` *(fails: Cannot find module '@magazine/domain')*

------
https://chatgpt.com/codex/tasks/task_e_68a28a5ce200832c9614991992e197fc