### PR TITLE
Move product link edit modal into table component

### DIFF
--- a/apps/visual-web/package.json
+++ b/apps/visual-web/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "next build",
-    "dev": "next dev --port 3001",
+    "dev": "next dev --port 3002",
     "lint": "next lint",
     "start": "next start",
     "test": "echo 1"

--- a/libs/admin/src/libs/products/components/EditProductLinkItem/EditProductLinkItem.tsx
+++ b/libs/admin/src/libs/products/components/EditProductLinkItem/EditProductLinkItem.tsx
@@ -1,7 +1,18 @@
+import { gql } from '@apollo/client';
 import { bind } from '@croco/utils-structure-react';
 import { Button, Group, Select, SelectProps, Stack, TextInput } from '@mantine/core';
 import { IconCheck } from '@tabler/icons-react';
 import { useEditProductLinkItem } from './useEditProductLinkItem';
+
+gql`
+  fragment EditProductLinkItem on Link {
+    id
+    title
+    link
+    displayLink
+    iconUrl
+  }
+`;
 
 export const EditProductLinkItem = bind(useEditProductLinkItem, ({ form, submit, loading }) => {
   return (

--- a/libs/admin/src/libs/products/components/EditProductLinkItem/__generated__/EditProductLinkItem.ts
+++ b/libs/admin/src/libs/products/components/EditProductLinkItem/__generated__/EditProductLinkItem.ts
@@ -1,0 +1,14 @@
+import * as Types from '@darun/provider-graphql';
+
+import { gql } from '@apollo/client';
+export type EditProductLinkItemFragment = { __typename?: 'Link', id: string, title: string, link: string, displayLink: string, iconUrl: string };
+
+export const EditProductLinkItemFragmentDoc = gql`
+    fragment EditProductLinkItem on Link {
+  id
+  title
+  link
+  displayLink
+  iconUrl
+}
+    `;

--- a/libs/admin/src/libs/products/components/EditProductLinkItem/__generated__/useEditProductLinkItem.ts
+++ b/libs/admin/src/libs/products/components/EditProductLinkItem/__generated__/useEditProductLinkItem.ts
@@ -11,7 +11,7 @@ export type UpdateProductLinkOnEditProductLinkItemMutationVariables = Types.Exac
 }>;
 
 
-export type UpdateProductLinkOnEditProductLinkItemMutation = { __typename?: 'Mutation', updateProductLink: { __typename?: 'UpdateProductLinkPayload', product?: { __typename?: 'Product', id: string, links: Array<{ __typename?: 'Link', id: string, title: string, link: string, displayLink: string, iconUrl: string, isPrimary: boolean }> } | null } };
+export type UpdateProductLinkOnEditProductLinkItemMutation = { __typename?: 'Mutation', updateProductLink: { __typename?: 'UpdateProductLinkPayload', product?: { __typename?: 'Product', id: string, links: Array<{ __typename?: 'Link', id: string, isPrimary: boolean, title: string, link: string, displayLink: string, iconUrl: string }> } | null } };
 
 
 export const UpdateProductLinkOnEditProductLinkItemDocument = gql`

--- a/libs/admin/src/libs/products/components/EditProductLinkItem/useEditProductLinkItem.ts
+++ b/libs/admin/src/libs/products/components/EditProductLinkItem/useEditProductLinkItem.ts
@@ -2,6 +2,7 @@ import { gql } from '@apollo/client';
 import { useForm } from '@mantine/form';
 import { notifications } from '@mantine/notifications';
 import { ProductLinkTableFragmentDoc } from '../ProductLinkTable/__generated__/ProductLinkTable';
+import { EditProductLinkItemFragment } from './__generated__/EditProductLinkItem';
 import { useUpdateProductLinkOnEditProductLinkItemMutation } from './__generated__/useEditProductLinkItem';
 
 gql`
@@ -19,13 +20,7 @@ gql`
 
 type EditProductLinkItemProps = {
   slug: string;
-  link: {
-    id: string;
-    title: string;
-    link: string;
-    displayLink: string;
-    iconUrl: string;
-  };
+  link: EditProductLinkItemFragment;
   onSubmit?: () => void;
 };
 

--- a/libs/admin/src/libs/products/components/ProductLinkTable/ProductLinkTable.tsx
+++ b/libs/admin/src/libs/products/components/ProductLinkTable/ProductLinkTable.tsx
@@ -1,7 +1,11 @@
+'use client';
+
 import { gql } from '@apollo/client';
 import { bind } from '@croco/utils-structure-react';
-import { Button, Group, rem, Table, Text } from '@mantine/core';
+import { Button, Group, Modal, rem, Table, Text } from '@mantine/core';
 import { IconPencil } from '@tabler/icons-react';
+import { EditProductLinkItem } from '../EditProductLinkItem';
+import { EditProductLinkItemFragmentDoc } from '../EditProductLinkItem/__generated__/EditProductLinkItem';
 import styles from './ProductFeatureTable.module.css';
 import { useProductLinkTable } from './useProductLinkTable';
 
@@ -9,86 +13,97 @@ gql`
   fragment ProductLinkTable on Product {
     links {
       id
-      title
-      link
-      displayLink
-      iconUrl
       isPrimary
+      ...EditProductLinkItem
     }
   }
+
+  ${EditProductLinkItemFragmentDoc}
 `;
 
-export const ProductLinkTable = bind(useProductLinkTable, ({ links, loading, editLink }) => {
-  if (loading) {
-    return <>로딩 중...</>;
-  }
+export const ProductLinkTable = bind(
+  useProductLinkTable,
+  ({ links, loading, editLink, isEditModalOpened, closeEditModal, link, slug }) => {
+    if (loading) {
+      return <>로딩 중...</>;
+    }
 
-  if (!links || links.length === 0) {
+    if (!links || links.length === 0) {
+      return (
+        <Text fz="sm" fw={500} c={'gray'}>
+          등록된 링크가 없습니다. 우측 상단 버튼으로 등록해보세요.
+        </Text>
+      );
+    }
+
     return (
-      <Text fz="sm" fw={500} c={'gray'}>
-        등록된 링크가 없습니다. 우측 상단 버튼으로 등록해보세요.
-      </Text>
+      <>
+        <Table.ScrollContainer minWidth={'300px'}>
+          <Table verticalSpacing="sm">
+            <Table.Thead>
+              <Table.Tr>
+                <Table.Th style={{ width: '80px', textAlign: 'center' }}>아이콘</Table.Th>
+                <Table.Th>이름</Table.Th>
+                <Table.Th>링크</Table.Th>
+                <Table.Th>주 링크 여부</Table.Th>
+              </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+              {links.map(link => (
+                <Table.Tr key={link.id} className={styles.table_row}>
+                  <Table.Td>
+                    <div
+                      style={{
+                        background: link.isPrimary ? '#000' : '#fff',
+                      }}
+                      className={styles.link_icon_wrapper}
+                    >
+                      <img src={link.iconUrl} />
+                    </div>
+                  </Table.Td>
+                  <Table.Td>
+                    <Text fz="sm" fw={500}>
+                      {link.title}
+                    </Text>
+                  </Table.Td>
+                  <Table.Td>
+                    <Text fz="sm" fw={500}>
+                      <a href={link.link} target="_blank">
+                        {link.displayLink} ({link.link})
+                      </a>
+                    </Text>
+                  </Table.Td>
+                  <Table.Td>
+                    <Text fz="sm" fw={500}>
+                      {link.isPrimary ? '✅' : '❌'}
+                    </Text>
+                  </Table.Td>
+                  <Table.Td>
+                    <Group gap={0} justify="flex-end">
+                      <Button
+                        justify="center"
+                        leftSection={<IconPencil style={{ width: rem(16), height: rem(16) }} stroke={1.5} />}
+                        variant="default"
+                        size={'compact-xs'}
+                        onClick={() => editLink(link)}
+                      >
+                        정보 수정
+                      </Button>
+                    </Group>
+                  </Table.Td>
+                </Table.Tr>
+              ))}
+            </Table.Tbody>
+          </Table>
+        </Table.ScrollContainer>
+        <Modal opened={isEditModalOpened} onClose={closeEditModal} title="링크 정보 수정" centered>
+          {link ? (
+            <EditProductLinkItem slug={slug} link={link} onSubmit={closeEditModal} />
+          ) : (
+            <>오류 발생. 새로고침 후 시도.</>
+          )}
+        </Modal>
+      </>
     );
   }
-
-  return (
-    <Table.ScrollContainer minWidth={'300px'}>
-      <Table verticalSpacing="sm">
-        <Table.Thead>
-          <Table.Tr>
-            <Table.Th style={{ width: '80px', textAlign: 'center' }}>아이콘</Table.Th>
-            <Table.Th>이름</Table.Th>
-            <Table.Th>링크</Table.Th>
-            <Table.Th>주 링크 여부</Table.Th>
-          </Table.Tr>
-        </Table.Thead>
-        <Table.Tbody>
-          {links.map(link => (
-            <Table.Tr key={link.id} className={styles.table_row}>
-              <Table.Td>
-                <div
-                  style={{
-                    background: link.isPrimary ? '#000' : '#fff',
-                  }}
-                  className={styles.link_icon_wrapper}
-                >
-                  <img src={link.iconUrl} />
-                </div>
-              </Table.Td>
-              <Table.Td>
-                <Text fz="sm" fw={500}>
-                  {link.title}
-                </Text>
-              </Table.Td>
-              <Table.Td>
-                <Text fz="sm" fw={500}>
-                  <a href={link.link} target="_blank">
-                    {link.displayLink} ({link.link})
-                  </a>
-                </Text>
-              </Table.Td>
-              <Table.Td>
-                <Text fz="sm" fw={500}>
-                  {link.isPrimary ? '✅' : '❌'}
-                </Text>
-              </Table.Td>
-              <Table.Td>
-                <Group gap={0} justify="flex-end">
-                  <Button
-                    justify="center"
-                    leftSection={<IconPencil style={{ width: rem(16), height: rem(16) }} stroke={1.5} />}
-                    variant="default"
-                    size={'compact-xs'}
-                    onClick={() => editLink(link)}
-                  >
-                    정보 수정
-                  </Button>
-                </Group>
-              </Table.Td>
-            </Table.Tr>
-          ))}
-        </Table.Tbody>
-      </Table>
-    </Table.ScrollContainer>
-  );
-});
+);

--- a/libs/admin/src/libs/products/components/ProductLinkTable/__generated__/ProductLinkTable.ts
+++ b/libs/admin/src/libs/products/components/ProductLinkTable/__generated__/ProductLinkTable.ts
@@ -1,17 +1,15 @@
 import * as Types from '@darun/provider-graphql';
 
 import { gql } from '@apollo/client';
-export type ProductLinkTableFragment = { __typename?: 'Product', links: Array<{ __typename?: 'Link', id: string, title: string, link: string, displayLink: string, iconUrl: string, isPrimary: boolean }> };
+import { EditProductLinkItemFragmentDoc } from '../../EditProductLinkItem/__generated__/EditProductLinkItem';
+export type ProductLinkTableFragment = { __typename?: 'Product', links: Array<{ __typename?: 'Link', id: string, isPrimary: boolean, title: string, link: string, displayLink: string, iconUrl: string }> };
 
 export const ProductLinkTableFragmentDoc = gql`
     fragment ProductLinkTable on Product {
   links {
     id
-    title
-    link
-    displayLink
-    iconUrl
     isPrimary
+    ...EditProductLinkItem
   }
 }
-    `;
+    ${EditProductLinkItemFragmentDoc}`;

--- a/libs/admin/src/libs/products/components/ProductLinkTable/__generated__/useProductLinkTable.ts
+++ b/libs/admin/src/libs/products/components/ProductLinkTable/__generated__/useProductLinkTable.ts
@@ -9,7 +9,7 @@ export type TempProductBySlugOnProductLinkTableQueryVariables = Types.Exact<{
 }>;
 
 
-export type TempProductBySlugOnProductLinkTableQuery = { __typename?: 'Query', tempProductBySlug?: { __typename?: 'Product', id: string, links: Array<{ __typename?: 'Link', id: string, title: string, link: string, displayLink: string, iconUrl: string, isPrimary: boolean }> } | null };
+export type TempProductBySlugOnProductLinkTableQuery = { __typename?: 'Query', tempProductBySlug?: { __typename?: 'Product', id: string, links: Array<{ __typename?: 'Link', id: string, isPrimary: boolean, title: string, link: string, displayLink: string, iconUrl: string }> } | null };
 
 
 export const TempProductBySlugOnProductLinkTableDocument = gql`

--- a/libs/admin/src/libs/products/components/ProductLinkTable/useProductLinkTable.ts
+++ b/libs/admin/src/libs/products/components/ProductLinkTable/useProductLinkTable.ts
@@ -1,4 +1,7 @@
 import { gql } from '@apollo/client';
+import { useDisclosure } from '@mantine/hooks';
+import { useCallback, useState } from 'react';
+import { EditProductLinkItemFragment } from '../EditProductLinkItem/__generated__/EditProductLinkItem';
 import { ProductLinkTableFragmentDoc } from './__generated__/ProductLinkTable';
 import { useTempProductBySlugOnProductLinkTableQuery } from './__generated__/useProductLinkTable';
 
@@ -15,17 +18,29 @@ gql`
 
 type ProductLinkTableProps = {
   slug: string;
-  editLink: (link: {
-    id: string;
-    title: string;
-    link: string;
-    displayLink: string;
-    iconUrl: string;
-    isPrimary?: boolean;
-  }) => void;
 };
 
-export function useProductLinkTable({ slug, editLink }: ProductLinkTableProps) {
+export function useProductLinkTable({ slug }: ProductLinkTableProps) {
   const { data, loading } = useTempProductBySlugOnProductLinkTableQuery({ variables: { slug } });
-  return { links: data?.tempProductBySlug?.links, loading, editLink };
+
+  const [isEditModalOpened, { open: openEditModal, close: closeEditModal }] = useDisclosure(false);
+  const [link, setLink] = useState<EditProductLinkItemFragment>();
+
+  const editLink = useCallback(
+    (selectedLink: EditProductLinkItemFragment) => {
+      setLink(selectedLink);
+      openEditModal();
+    },
+    [openEditModal]
+  );
+
+  return {
+    links: data?.tempProductBySlug?.links,
+    loading,
+    editLink,
+    isEditModalOpened,
+    closeEditModal,
+    link,
+    slug,
+  };
 }

--- a/libs/admin/src/libs/products/shells/ProductDetailLinkSection/ProductDetailLinkSection.tsx
+++ b/libs/admin/src/libs/products/shells/ProductDetailLinkSection/ProductDetailLinkSection.tsx
@@ -1,35 +1,26 @@
 import { bind } from '@croco/utils-structure-react';
-import { Button, Card, Group, Modal, Stack, Title, Text } from '@mantine/core';
+import { Button, Card, Group, Stack, Title, Text } from '@mantine/core';
 import Link from 'next/link';
 import { ProductLinkTable } from '../../components/ProductLinkTable';
 import { useProductDetailLinkSection } from './useProductDetailLinkSection';
-import { EditProductLinkItem } from '../../components/EditProductLinkItem';
 
-export const ProductDetailLinkSection = bind(
-  useProductDetailLinkSection,
-  ({ slug, isEditModalOpened, closeEditModal, editLink, link }) => (
-    <>
-      <Stack gap={8}>
-        <Group justify={'space-between'}>
-          <Stack gap={0}>
-            <Title order={3}>링크 관리</Title>
-            <Text c="dimmed" fw={500} size="sm">
-              서비스 정보에서 목차 위에 표시되는 링크 버튼에 뜨는 버튼들을 관리합니다.
-            </Text>
-          </Stack>
-          <Link href={`/products/${slug}/links/new`}>
-            <Button color={'dark'}>새 링크 추가</Button>
-          </Link>
-        </Group>
-        <Card withBorder shadow="sm" radius="md">
-          <Card.Section withBorder inheritPadding py="xs">
-            <ProductLinkTable slug={slug} editLink={editLink} />
-          </Card.Section>
-        </Card>
+export const ProductDetailLinkSection = bind(useProductDetailLinkSection, ({ slug }) => (
+  <Stack gap={8}>
+    <Group justify={'space-between'}>
+      <Stack gap={0}>
+        <Title order={3}>링크 관리</Title>
+        <Text c="dimmed" fw={500} size="sm">
+          서비스 정보에서 목차 위에 표시되는 링크 버튼에 뜨는 버튼들을 관리합니다.
+        </Text>
       </Stack>
-      <Modal opened={isEditModalOpened} onClose={closeEditModal} title="링크 정보 수정" centered>
-        {link ? <EditProductLinkItem slug={slug} link={link} onSubmit={closeEditModal} /> : <>오류 발생. 새로고침 후 시도.</>}
-      </Modal>
-    </>
-  )
-);
+      <Link href={`/products/${slug}/links/new`}>
+        <Button color={'dark'}>새 링크 추가</Button>
+      </Link>
+    </Group>
+    <Card withBorder shadow="sm" radius="md">
+      <Card.Section withBorder inheritPadding py="xs">
+        <ProductLinkTable slug={slug} />
+      </Card.Section>
+    </Card>
+  </Stack>
+));

--- a/libs/admin/src/libs/products/shells/ProductDetailLinkSection/useProductDetailLinkSection.ts
+++ b/libs/admin/src/libs/products/shells/ProductDetailLinkSection/useProductDetailLinkSection.ts
@@ -1,27 +1,7 @@
-import { useDisclosure } from '@mantine/hooks';
-import { useCallback, useState } from 'react';
-
 type ProductDetailLinkSectionProps = {
   slug: string;
 };
 
 export function useProductDetailLinkSection({ slug }: ProductDetailLinkSectionProps) {
-  const [isEditModalOpened, { open: openEditModal, close: closeEditModal }] = useDisclosure(false);
-  const [link, setLink] = useState<{
-    id: string;
-    title: string;
-    link: string;
-    displayLink: string;
-    iconUrl: string;
-  }>();
-
-  const editLink = useCallback(
-    (selectedLink: { id: string; title: string; link: string; displayLink: string; iconUrl: string }) => {
-      setLink(selectedLink);
-      openEditModal();
-    },
-    [openEditModal]
-  );
-
-  return { slug, isEditModalOpened, closeEditModal, editLink, link };
+  return { slug };
 }


### PR DESCRIPTION
## Summary
- manage edit modal state inside `ProductLinkTable`
- streamline `ProductDetailLinkSection` to just render the table

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck` *(fails: Cannot find module '@magazine/domain' for apps/graphql-api; requires Node >=22)*

------
https://chatgpt.com/codex/tasks/task_e_68a296e82a70832cba122f636e0f31a4