### PR TITLE
feat: enable company search for product linking

### DIFF
--- a/apps/graphql-api/schema.graphql
+++ b/apps/graphql-api/schema.graphql
@@ -243,6 +243,7 @@ type PublishProductPayload {
 
 type Query {
   allCompanies(page: Int!): CompanyPagination!
+  searchCompanies(query: String!): [Company!]!
   allProducts(after: String, before: String, first: Int, last: Int): ProductConnection!
   feature(id: ID!): Feature
   hello: String!

--- a/apps/graphql-api/src/app/graphql/company/Company.query.resolver.ts
+++ b/apps/graphql-api/src/app/graphql/company/Company.query.resolver.ts
@@ -1,4 +1,4 @@
-import { GetAllCompanies } from '@darun/backend';
+import { GetAllCompanies, SearchCompany } from '@darun/backend';
 import { AuthRole } from '@darun/utils-apollo-server';
 import { Arg, Authorized, Int, Query, Resolver } from 'type-graphql';
 import { Service } from 'typedi';
@@ -8,7 +8,10 @@ import { CompanyPagination } from './graphs/CompanyPagination';
 @Resolver(() => Company)
 @Service()
 export class CompanyQueryResolver {
-  constructor(private readonly getAllCompanies: GetAllCompanies) {}
+  constructor(
+    private readonly getAllCompanies: GetAllCompanies,
+    private readonly searchCompany: SearchCompany
+  ) {}
 
   @Authorized([AuthRole.Admin])
   @Query(() => CompanyPagination)
@@ -21,5 +24,11 @@ export class CompanyQueryResolver {
       totalPages: Math.ceil(total / limit),
       companies: data,
     };
+  }
+
+  @Authorized([AuthRole.Admin])
+  @Query(() => [Company])
+  public async searchCompanies(@Arg('query') query: string): Promise<Company[]> {
+    return this.searchCompany.execute({ query });
   }
 }

--- a/libs/admin/src/libs/products/components/EditProductCompany/EditProductCompany.tsx
+++ b/libs/admin/src/libs/products/components/EditProductCompany/EditProductCompany.tsx
@@ -1,15 +1,22 @@
 import { bind } from '@croco/utils-structure-react';
-import { Button, Group, Stack, TextInput } from '@mantine/core';
+import { Button, Group, Select, Stack } from '@mantine/core';
 import { useEditProductCompany } from './useEditProductCompany';
 
-export const EditProductCompany = bind(useEditProductCompany, ({ form, handleSubmit }) => (
+export const EditProductCompany = bind(useEditProductCompany, ({ form, handleSubmit, companies, searchCompany }) => (
   <form onSubmit={form.onSubmit(handleSubmit)}>
     <Stack gap={'8px'}>
-      <TextInput
-        label="회사 ID"
-        placeholder="ex) 01J8H7WF8CPNB7Y6RZXC26B1MA"
-        key={form.key('id')}
-        {...form.getInputProps('id')}
+      <Select
+        label="회사"
+        placeholder="회사 이름을 검색하세요."
+        data={companies}
+        searchable
+        onSearchChange={value => {
+          form.setFieldValue('query', value);
+          searchCompany(value);
+        }}
+        onChange={value => form.setFieldValue('companyId', value || '')}
+        value={form.getValues().companyId}
+        key={form.key('query')}
       />
     </Stack>
 

--- a/libs/admin/src/libs/products/components/EditProductCompany/__generated__/useEditProductCompany.ts
+++ b/libs/admin/src/libs/products/components/EditProductCompany/__generated__/useEditProductCompany.ts
@@ -11,6 +11,13 @@ export type RegisterProductCompanyOnEditProductCompanyMutationVariables = Types.
 
 export type RegisterProductCompanyOnEditProductCompanyMutation = { __typename?: 'Mutation', registerProductCompany: { __typename?: 'RegisterProductCompanyPayload', product?: { __typename?: 'Product', id: string } | null } };
 
+export type SearchCompaniesOnEditProductCompanyQueryVariables = Types.Exact<{
+  query: Types.Scalars['String']['input'];
+}>;
+
+
+export type SearchCompaniesOnEditProductCompanyQuery = { __typename?: 'Query', searchCompanies: Array<{ __typename?: 'Company', id: string, name: string }> };
+
 
 export const RegisterProductCompanyOnEditProductCompanyDocument = gql`
     mutation RegisterProductCompanyOnEditProductCompany($input: RegisterProductCompanyInput!, $slug: String!) {
@@ -48,3 +55,44 @@ export function useRegisterProductCompanyOnEditProductCompanyMutation(baseOption
 export type RegisterProductCompanyOnEditProductCompanyMutationHookResult = ReturnType<typeof useRegisterProductCompanyOnEditProductCompanyMutation>;
 export type RegisterProductCompanyOnEditProductCompanyMutationResult = Apollo.MutationResult<RegisterProductCompanyOnEditProductCompanyMutation>;
 export type RegisterProductCompanyOnEditProductCompanyMutationOptions = Apollo.BaseMutationOptions<RegisterProductCompanyOnEditProductCompanyMutation, RegisterProductCompanyOnEditProductCompanyMutationVariables>;
+export const SearchCompaniesOnEditProductCompanyDocument = gql`
+    query SearchCompaniesOnEditProductCompany($query: String!) {
+  searchCompanies(query: $query) {
+    id
+    name
+  }
+}
+    `;
+
+/**
+ * __useSearchCompaniesOnEditProductCompanyQuery__
+ *
+ * To run a query within a React component, call `useSearchCompaniesOnEditProductCompanyQuery` and pass it any options that fit your needs.
+ * When your component renders, `useSearchCompaniesOnEditProductCompanyQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useSearchCompaniesOnEditProductCompanyQuery({
+ *   variables: {
+ *      query: // value for 'query'
+ *   },
+ * });
+ */
+export function useSearchCompaniesOnEditProductCompanyQuery(baseOptions: Apollo.QueryHookOptions<SearchCompaniesOnEditProductCompanyQuery, SearchCompaniesOnEditProductCompanyQueryVariables> & ({ variables: SearchCompaniesOnEditProductCompanyQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<SearchCompaniesOnEditProductCompanyQuery, SearchCompaniesOnEditProductCompanyQueryVariables>(SearchCompaniesOnEditProductCompanyDocument, options);
+      }
+export function useSearchCompaniesOnEditProductCompanyLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<SearchCompaniesOnEditProductCompanyQuery, SearchCompaniesOnEditProductCompanyQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<SearchCompaniesOnEditProductCompanyQuery, SearchCompaniesOnEditProductCompanyQueryVariables>(SearchCompaniesOnEditProductCompanyDocument, options);
+        }
+export function useSearchCompaniesOnEditProductCompanySuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<SearchCompaniesOnEditProductCompanyQuery, SearchCompaniesOnEditProductCompanyQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<SearchCompaniesOnEditProductCompanyQuery, SearchCompaniesOnEditProductCompanyQueryVariables>(SearchCompaniesOnEditProductCompanyDocument, options);
+        }
+export type SearchCompaniesOnEditProductCompanyQueryHookResult = ReturnType<typeof useSearchCompaniesOnEditProductCompanyQuery>;
+export type SearchCompaniesOnEditProductCompanyLazyQueryHookResult = ReturnType<typeof useSearchCompaniesOnEditProductCompanyLazyQuery>;
+export type SearchCompaniesOnEditProductCompanySuspenseQueryHookResult = ReturnType<typeof useSearchCompaniesOnEditProductCompanySuspenseQuery>;
+export type SearchCompaniesOnEditProductCompanyQueryResult = Apollo.QueryResult<SearchCompaniesOnEditProductCompanyQuery, SearchCompaniesOnEditProductCompanyQueryVariables>;

--- a/libs/admin/src/libs/products/components/EditProductCompany/useEditProductCompany.ts
+++ b/libs/admin/src/libs/products/components/EditProductCompany/useEditProductCompany.ts
@@ -1,9 +1,13 @@
 import { gql, useApolloClient } from '@apollo/client';
 import { useForm } from '@mantine/form';
+import { useThrottledCallback } from '@mantine/hooks';
 import { notifications } from '@mantine/notifications';
 import { useRouter } from 'next/navigation';
 import { TempProductBySlugOnProductCompanyInfoDocument } from '../ProductCompanyInfo/__generated__/useProductCompanyInfo';
-import { useRegisterProductCompanyOnEditProductCompanyMutation } from './__generated__/useEditProductCompany';
+import {
+  useRegisterProductCompanyOnEditProductCompanyMutation,
+  useSearchCompaniesOnEditProductCompanyLazyQuery,
+} from './__generated__/useEditProductCompany';
 
 gql`
   mutation RegisterProductCompanyOnEditProductCompany($input: RegisterProductCompanyInput!, $slug: String!) {
@@ -15,8 +19,18 @@ gql`
   }
 `;
 
+gql`
+  query SearchCompaniesOnEditProductCompany($query: String!) {
+    searchCompanies(query: $query) {
+      id
+      name
+    }
+  }
+`;
+
 type FormValues = {
-  id?: string;
+  companyId: string;
+  query: string;
 };
 
 export function useEditProductCompany({ slug }: { slug: string }) {
@@ -39,20 +53,34 @@ export function useEditProductCompany({ slug }: { slug: string }) {
     },
   });
 
+  const [search, { data }] = useSearchCompaniesOnEditProductCompanyLazyQuery();
+
+  const searchCompany = useThrottledCallback(async (query: string) => {
+    if (!query) return;
+
+    await search({ variables: { query } });
+  }, 500);
+
   const form = useForm<FormValues>({
     mode: 'uncontrolled',
     initialValues: {
-      id: '',
+      companyId: '',
+      query: '',
     },
   });
 
   const handleSubmit = (values: FormValues) => {
-    if (!values.id) {
+    if (!values.companyId) {
       notifications.show({ message: '값을 입력해주세요!!', color: 'red' });
       return;
     }
-    registerProductCompany({ variables: { input: { companyId: values.id }, slug } });
+    registerProductCompany({ variables: { input: { companyId: values.companyId }, slug } });
   };
 
-  return { form, handleSubmit };
+  return {
+    form,
+    handleSubmit,
+    companies: data?.searchCompanies.map(({ id, name }) => ({ label: name, value: id })) ?? [],
+    searchCompany,
+  };
 }

--- a/libs/backend/src/index.ts
+++ b/libs/backend/src/index.ts
@@ -22,7 +22,7 @@ export {
   RegisterProductCompany,
 } from './libs/products/domain';
 export { GetAccount, GetProfile } from './libs/accounts/domain';
-export { GetCompany, CreateCompany, GetAllCompanies } from './libs/companies/domain';
+export { GetCompany, CreateCompany, GetAllCompanies, SearchCompany } from './libs/companies/domain';
 export { IndexProduct, SearchProduct } from './libs/search/domain';
 export { GetAlternativeProducts, UpdateAlternativeProduct } from './libs/recommendation/domain';
 export { SignImageUpload } from './libs/images/domain';

--- a/libs/backend/src/libs/companies/datasource/repositories/PostgresqlCompanyRepository.ts
+++ b/libs/backend/src/libs/companies/datasource/repositories/PostgresqlCompanyRepository.ts
@@ -1,7 +1,7 @@
 import { Company, CompanyRepository, CompanyRepositoryToken } from '@companies/domain';
 import { Drizzle, DrizzleToken } from '@darun/provider-database';
 import DataLoader from 'dataloader';
-import { count, inArray } from 'drizzle-orm';
+import { count, ilike, inArray } from 'drizzle-orm';
 import { keyBy } from 'es-toolkit';
 import { Inject, Service } from 'typedi';
 import { companies } from '../entities/CompanySchema';
@@ -37,6 +37,14 @@ export class PostgresqlCompanyRepository implements CompanyRepository {
 
   async findById(id: string): Promise<Company | null> {
     return this.companyIdLoader.load(id);
+  }
+
+  async findByName(name: string): Promise<Company[]> {
+    return this.db
+      .select()
+      .from(companies)
+      .where(ilike(companies.name, `%${name}%`))
+      .then(res => res.map(this.mapper));
   }
 
   async findAllWithPagination(page: number = 1, limit: number = 50): Promise<{ data: Company[]; total: number }> {

--- a/libs/backend/src/libs/companies/domain/index.ts
+++ b/libs/backend/src/libs/companies/domain/index.ts
@@ -5,3 +5,4 @@ export { Company } from './entities/Company';
 export { GetCompany } from './usecases/GetCompany';
 export { GetAllCompanies } from './usecases/GetAllCompanies';
 export { CreateCompany } from './usecases/CreateCompany';
+export { SearchCompany } from './usecases/SearchCompany';

--- a/libs/backend/src/libs/companies/domain/repositories/CompanyRepository.ts
+++ b/libs/backend/src/libs/companies/domain/repositories/CompanyRepository.ts
@@ -4,6 +4,7 @@ import { Company } from '../entities/Company';
 export interface CompanyRepository {
   findById(id: string): Promise<Company | null>;
   findAllWithPagination(page: number, limit: number): Promise<{ data: Company[]; total: number }>;
+  findByName(name: string): Promise<Company[]>;
   insert(values: Company): Promise<Company | null>;
 }
 

--- a/libs/backend/src/libs/companies/domain/usecases/SearchCompany.ts
+++ b/libs/backend/src/libs/companies/domain/usecases/SearchCompany.ts
@@ -1,0 +1,12 @@
+import { Inject, Service } from 'typedi';
+import { Company } from '../entities/Company';
+import { CompanyRepository, CompanyRepositoryToken } from '../repositories/CompanyRepository';
+
+@Service()
+export class SearchCompany {
+  constructor(@Inject(CompanyRepositoryToken) private readonly companyRepository: CompanyRepository) {}
+
+  execute({ query }: { query: string }): Promise<Company[]> {
+    return this.companyRepository.findByName(query);
+  }
+}

--- a/libs/shared/provider-graphql/src/index.ts
+++ b/libs/shared/provider-graphql/src/index.ts
@@ -385,6 +385,7 @@ export type Query = {
   readonly productBySlug?: Maybe<Product>;
   readonly productsCount: Scalars['Int']['output'];
   readonly recentProducts: ReadonlyArray<Product>;
+  readonly searchCompanies: ReadonlyArray<Company>;
   readonly searchProducts: ReadonlyArray<Product>;
   readonly tempAllMagazines: MagazinePagination;
   readonly tempMagazineBySlug?: Maybe<Magazine>;
@@ -432,6 +433,11 @@ export type QueryproductBySlugArgs = {
 
 export type QueryrecentProductsArgs = {
   first: Scalars['Int']['input'];
+};
+
+
+export type QuerysearchCompaniesArgs = {
+  query: Scalars['String']['input'];
 };
 
 


### PR DESCRIPTION
## Summary
- rename searchCompanies argument to `query`
- propagate query param across backend and admin product-company editor
- store search text in form and update dropdown key
- track selected company with a dedicated `companyId` form field
- drop unused `id` field from product-company form

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2d0eb9c30832ca0f1b4c4c3bd1930