### PR TITLE
fix(admin): change startAt type from Date to string in NewCompanyForm

### DIFF
--- a/apps/graphql-api/serverless.yaml
+++ b/apps/graphql-api/serverless.yaml
@@ -1,5 +1,5 @@
-org: croco
-app: darun
+# org: croco
+# app: darun
 service: graphql-api
 frameworkVersion: '4'
 

--- a/apps/graphql-api/serverless.yaml
+++ b/apps/graphql-api/serverless.yaml
@@ -1,5 +1,5 @@
-# org: croco
-# app: darun
+org: croco
+app: darun
 service: graphql-api
 frameworkVersion: '4'
 

--- a/libs/admin/src/libs/companies/components/NewCompanyForm/useNewCompanyForm.ts
+++ b/libs/admin/src/libs/companies/components/NewCompanyForm/useNewCompanyForm.ts
@@ -19,7 +19,7 @@ type FormValues = {
   name?: string;
   type?: string;
   address?: string;
-  startAt?: Date;
+  startAt?: string;
   startAtIsDisabled: boolean;
 };
 
@@ -29,7 +29,7 @@ export function useNewCompanyForm() {
       name: '',
       type: '',
       address: '',
-      startAt: new Date(),
+      startAt: '',
       startAtIsDisabled: false,
     },
     mode: 'uncontrolled',
@@ -55,7 +55,7 @@ export function useNewCompanyForm() {
           name: values.name,
           type: values.type,
           address: values.address,
-          startAt: values.startAtIsDisabled ? undefined : values.startAt,
+          startAt: values.startAtIsDisabled ? undefined : values.startAt && new Date(values.startAt),
         },
       },
     });


### PR DESCRIPTION
- mantine date 입력에서 js date 객체가 아니라 string이 나오도록 변경된 것 같아요.
- Update the startAt field in the new company form to use string type instead of Date, and adjust initialization and submission logic accordingly to resolve date handling issues.

