### PR TITLE
fix(datasource): clear DataLoader cache after product mutations

### DIFF
--- a/libs/products/datasource/package.json
+++ b/libs/products/datasource/package.json
@@ -6,7 +6,7 @@
   "types": "./src/index.ts",
   "scripts": {
     "lint": "eslint **/*.ts*",
-    "test": "echo 1",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/libs/products/datasource/src/__tests__/PostgresqlProductFeatureProductLinkRepository.test.ts
+++ b/libs/products/datasource/src/__tests__/PostgresqlProductFeatureProductLinkRepository.test.ts
@@ -1,0 +1,226 @@
+import { ProductFeature, ProductLink } from '@darun/products-domain';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PostgresqlProductFeatureRepository } from '../repositories/PostgresqlProductFeatureRepository';
+import { PostgresqlProductLinkRepository } from '../repositories/PostgresqlProductLinkRepository';
+
+vi.hoisted(() => {
+  process.env.VOTE_IP_SALT = 'test-salt';
+});
+
+const { mockClearAll } = vi.hoisted(() => ({
+  mockClearAll: vi.fn(),
+}));
+
+vi.mock('dataloader', () => ({
+  default: vi.fn(function () {
+    return {
+      load: vi.fn(),
+      clearAll: mockClearAll,
+    };
+  }),
+}));
+
+describe('PostgresqlProductFeatureRepository', () => {
+  const mockTx = {
+    insert: vi.fn().mockReturnThis(),
+    values: vi.fn().mockReturnThis(),
+    returning: vi.fn(),
+    select: vi.fn().mockReturnThis(),
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    update: vi.fn().mockReturnThis(),
+    set: vi.fn().mockReturnThis(),
+  };
+
+  const mockDb = {
+    transaction: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDb.transaction.mockImplementation(async (cb: (tx: typeof mockTx) => Promise<unknown>) => cb(mockTx));
+  });
+
+  describe('insert()', () => {
+    it('should call clearAll() after insert()', async () => {
+      const repo = new PostgresqlProductFeatureRepository(
+        mockDb as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      );
+      const feature = new ProductFeature({
+        id: 'feature-1',
+        name: 'Test Feature',
+        emoji: '🚀',
+        productId: 'product-1',
+      });
+
+      mockTx.returning.mockResolvedValue([feature]);
+
+      const result = await repo.insert(feature);
+
+      expect(result).toEqual(feature);
+      expect(mockClearAll).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return the inserted feature', async () => {
+      const repo = new PostgresqlProductFeatureRepository(
+        mockDb as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      );
+      const feature = new ProductFeature({
+        id: 'feature-2',
+        name: 'Another Feature',
+        emoji: '✨',
+        productId: 'product-1',
+      });
+
+      mockTx.returning.mockResolvedValue([feature]);
+
+      const result = await repo.insert(feature);
+
+      expect(result.id).toBe('feature-2');
+      expect(result.name).toBe('Another Feature');
+      expect(result.emoji).toBe('✨');
+      expect(result.productId).toBe('product-1');
+    });
+  });
+
+  describe('updateById()', () => {
+    it('should call clearAll() after updateById()', async () => {
+      const repo = new PostgresqlProductFeatureRepository(
+        mockDb as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      );
+      const existingFeature = new ProductFeature({
+        id: 'feature-1',
+        name: 'Original',
+        emoji: '🚀',
+        productId: 'product-1',
+      });
+      const updatedFeature = new ProductFeature({
+        id: 'feature-1',
+        name: 'Updated',
+        emoji: '🔥',
+        productId: 'product-1',
+      });
+
+      mockTx.limit.mockResolvedValue([existingFeature]);
+      mockTx.returning.mockResolvedValue([updatedFeature]);
+
+      const result = await repo.updateById('feature-1', f => {
+        f.update({ name: 'Updated', emoji: '🔥' });
+        return f;
+      });
+
+      expect(result).toEqual(updatedFeature);
+      expect(mockClearAll).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+describe('PostgresqlProductLinkRepository', () => {
+  const mockTx = {
+    insert: vi.fn().mockReturnThis(),
+    values: vi.fn().mockReturnThis(),
+    returning: vi.fn(),
+    select: vi.fn().mockReturnThis(),
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    update: vi.fn().mockReturnThis(),
+    set: vi.fn().mockReturnThis(),
+  };
+
+  const mockDb = {
+    transaction: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDb.transaction.mockImplementation(async (cb: (tx: typeof mockTx) => Promise<unknown>) => cb(mockTx));
+  });
+
+  describe('insert()', () => {
+    it('should call clearAll() after insert()', async () => {
+      const repo = new PostgresqlProductLinkRepository(
+        mockDb as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      );
+      const link = new ProductLink({
+        id: 'link-1',
+        title: 'Test Link',
+        link: 'https://example.com',
+        displayLink: 'example.com',
+        iconUrl: 'https://example.com/icon.png',
+        productId: 'product-1',
+      });
+
+      mockTx.returning.mockResolvedValue([link]);
+
+      const result = await repo.insert(link);
+
+      expect(result).toEqual(link);
+      expect(mockClearAll).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return the inserted link', async () => {
+      const repo = new PostgresqlProductLinkRepository(
+        mockDb as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      );
+      const link = new ProductLink({
+        id: 'link-2',
+        title: 'Docs',
+        link: 'https://docs.example.com',
+        displayLink: 'docs.example.com',
+        iconUrl: 'https://example.com/docs-icon.png',
+        productId: 'product-2',
+      });
+
+      mockTx.returning.mockResolvedValue([link]);
+
+      const result = await repo.insert(link);
+
+      expect(result.id).toBe('link-2');
+      expect(result.title).toBe('Docs');
+      expect(result.link).toBe('https://docs.example.com');
+      expect(result.productId).toBe('product-2');
+    });
+  });
+
+  describe('updateById()', () => {
+    it('should call clearAll() after updateById()', async () => {
+      const repo = new PostgresqlProductLinkRepository(
+        mockDb as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      );
+      const existingLink = new ProductLink({
+        id: 'link-1',
+        title: 'Original',
+        link: 'https://example.com',
+        displayLink: 'example.com',
+        iconUrl: 'https://example.com/icon.png',
+        productId: 'product-1',
+      });
+      const updatedLink = new ProductLink({
+        id: 'link-1',
+        title: 'Updated',
+        link: 'https://updated.example.com',
+        displayLink: 'updated.example.com',
+        iconUrl: 'https://example.com/new-icon.png',
+        productId: 'product-1',
+      });
+
+      mockTx.limit.mockResolvedValue([existingLink]);
+      mockTx.returning.mockResolvedValue([updatedLink]);
+
+      const result = await repo.updateById('link-1', l => {
+        l.update({
+          title: 'Updated',
+          link: 'https://updated.example.com',
+          displayLink: 'updated.example.com',
+          iconUrl: 'https://example.com/new-icon.png',
+        });
+        return l;
+      });
+
+      expect(result).toEqual(updatedLink);
+      expect(mockClearAll).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/libs/products/datasource/src/__tests__/PostgresqlProductRepository.test.ts
+++ b/libs/products/datasource/src/__tests__/PostgresqlProductRepository.test.ts
@@ -1,0 +1,59 @@
+import 'reflect-metadata';
+import { Product } from '@darun/products-domain';
+import DataLoader from 'dataloader';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { PostgresqlProductRepository } from '../repositories/PostgresqlProductRepository';
+
+describe('PostgresqlProductRepository DataLoader cache invalidation', () => {
+  let mockDb: { transaction: ReturnType<typeof vi.fn> };
+  let clearAllSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    mockDb = {
+      transaction: vi.fn(),
+    };
+    clearAllSpy = vi.spyOn(DataLoader.prototype, 'clearAll');
+  });
+
+  afterEach(() => {
+    clearAllSpy.mockRestore();
+  });
+
+  describe('insert()', () => {
+    it('should call publishedIdLoader.clearAll() after successful insert', async () => {
+      const product = new Product({
+        id: 'product-1',
+        slug: 'test-product',
+        name: 'Test Product',
+        summary: 'A test product',
+        logoUrl: 'https://example.com/logo.png',
+      });
+      mockDb.transaction.mockResolvedValue(product);
+      const repository = new PostgresqlProductRepository(mockDb as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+      const result = await repository.insert(product);
+
+      expect(result).toBe(product);
+      expect(clearAllSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('updateById()', () => {
+    it('should call publishedIdLoader.clearAll() after successful update', async () => {
+      const product = new Product({
+        id: 'product-1',
+        slug: 'test-product',
+        name: 'Test Product',
+        summary: 'A test product',
+        logoUrl: 'https://example.com/logo.png',
+      });
+      mockDb.transaction.mockResolvedValue(product);
+      const repository = new PostgresqlProductRepository(mockDb as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+      const result = await repository.updateById('product-1', (p: Product) => p);
+
+      expect(result).toBe(product);
+      expect(clearAllSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/libs/products/datasource/src/__tests__/PostgresqlProductScreenshotRepository.test.ts
+++ b/libs/products/datasource/src/__tests__/PostgresqlProductScreenshotRepository.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PostgresqlProductScreenshotRepository } from '../repositories/PostgresqlProductScreenshotRepository';
+
+vi.hoisted(() => {
+  process.env.VOTE_IP_SALT = 'test-salt';
+});
+
+const { mockClearAll } = vi.hoisted(() => ({
+  mockClearAll: vi.fn(),
+}));
+
+vi.mock('dataloader', () => ({
+  default: vi.fn(function () {
+    return {
+      load: vi.fn(),
+      clearAll: mockClearAll,
+    };
+  }),
+}));
+
+describe('PostgresqlProductScreenshotRepository', () => {
+  const mockTx = {
+    insert: vi.fn().mockReturnThis(),
+    values: vi.fn().mockReturnThis(),
+    returning: vi.fn(),
+  };
+
+  const mockDb = {
+    transaction: vi.fn(),
+    delete: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDb.transaction.mockImplementation(async (cb: (tx: typeof mockTx) => Promise<unknown>) => cb(mockTx));
+    mockDb.delete.mockReturnValue({
+      where: vi.fn().mockResolvedValue(undefined),
+    });
+  });
+
+  it('should call clearAll() after insert()', async () => {
+    const repo = new PostgresqlProductScreenshotRepository(mockDb as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+    const screenshot = {
+      id: 'test-1',
+      productId: 'product-1',
+      imageUrl: 'https://example.com/img.png',
+      imageAlt: 'Test image',
+    };
+
+    mockTx.returning.mockResolvedValue([screenshot]);
+
+    const result = await repo.insert(screenshot as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+    expect(result).toEqual(screenshot);
+    expect(mockClearAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call clearAll() after deleteById()', async () => {
+    const repo = new PostgresqlProductScreenshotRepository(mockDb as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+    await repo.deleteById('screenshot-1');
+
+    expect(mockClearAll).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/products/datasource/src/repositories/PostgresqlProductFeatureRepository.ts
+++ b/libs/products/datasource/src/repositories/PostgresqlProductFeatureRepository.ts
@@ -33,40 +33,50 @@ export class PostgresqlProductFeatureRepository implements ProductFeatureReposit
   }
 
   insert(newFeature: ProductFeature): Promise<ProductFeature> {
-    return this.db.transaction(async tx => {
-      const inserted = await tx
-        .insert(productFeatures)
-        .values({ ...newFeature })
-        .returning();
+    return this.db
+      .transaction(async tx => {
+        const inserted = await tx
+          .insert(productFeatures)
+          .values({ ...newFeature })
+          .returning();
 
-      return this.mapper(inserted[0]);
-    });
+        return this.mapper(inserted[0]);
+      })
+      .then(result => {
+        this.productIdLoader.clearAll();
+        return result;
+      });
   }
 
   updateById(featureId: string, modifier: (feature: ProductFeature) => ProductFeature): Promise<ProductFeature> {
-    return this.db.transaction(async tx => {
-      const prevFeature = await tx
-        .select()
-        .from(productFeatures)
-        .where(eq(productFeatures.id, featureId))
-        .limit(1)
-        .then(rows => (rows[0] ? this.mapper(rows[0]) : null));
+    return this.db
+      .transaction(async tx => {
+        const prevFeature = await tx
+          .select()
+          .from(productFeatures)
+          .where(eq(productFeatures.id, featureId))
+          .limit(1)
+          .then(rows => (rows[0] ? this.mapper(rows[0]) : null));
 
-      if (!prevFeature) {
-        throw new Error('ProductFeature not found');
-      }
+        if (!prevFeature) {
+          throw new Error('ProductFeature not found');
+        }
 
-      const updated = await tx
-        .update(productFeatures)
-        .set({ ...modifier(prevFeature) })
-        .where(eq(productFeatures.id, featureId))
-        .returning();
-      if (!updated[0]) {
-        throw new Error('ProductFeature update failed');
-      }
+        const updated = await tx
+          .update(productFeatures)
+          .set({ ...modifier(prevFeature) })
+          .where(eq(productFeatures.id, featureId))
+          .returning();
+        if (!updated[0]) {
+          throw new Error('ProductFeature update failed');
+        }
 
-      return this.mapper(updated[0]);
-    });
+        return this.mapper(updated[0]);
+      })
+      .then(result => {
+        this.productIdLoader.clearAll();
+        return result;
+      });
   }
 
   async findOneById(id: string): Promise<ProductFeature | null> {

--- a/libs/products/datasource/src/repositories/PostgresqlProductLinkRepository.ts
+++ b/libs/products/datasource/src/repositories/PostgresqlProductLinkRepository.ts
@@ -32,14 +32,19 @@ export class PostgresqlProductLinkRepository implements ProductLinkRepository {
   }
 
   insert(link: ProductLink): Promise<ProductLink> {
-    return this.db.transaction(async tx => {
-      const inserted = await tx.insert(productLinks).values(link).returning();
+    return this.db
+      .transaction(async tx => {
+        const inserted = await tx.insert(productLinks).values(link).returning();
 
-      if (!inserted[0]) {
-        throw new Error('Failed to insert product screenshot');
-      }
-      return this.mapper(inserted[0]);
-    });
+        if (!inserted[0]) {
+          throw new Error('Failed to insert product screenshot');
+        }
+        return this.mapper(inserted[0]);
+      })
+      .then(result => {
+        this.productIdLoader.clearAll();
+        return result;
+      });
   }
 
   async findManyByProductId(productId: string): Promise<ProductLink[]> {
@@ -47,30 +52,35 @@ export class PostgresqlProductLinkRepository implements ProductLinkRepository {
   }
 
   updateById(linkId: string, modifier: (link: ProductLink) => ProductLink): Promise<ProductLink> {
-    return this.db.transaction(async tx => {
-      const prevLink = await tx
-        .select()
-        .from(productLinks)
-        .where(eq(productLinks.id, linkId))
-        .limit(1)
-        .then(rows => (rows[0] ? this.mapper(rows[0]) : null));
+    return this.db
+      .transaction(async tx => {
+        const prevLink = await tx
+          .select()
+          .from(productLinks)
+          .where(eq(productLinks.id, linkId))
+          .limit(1)
+          .then(rows => (rows[0] ? this.mapper(rows[0]) : null));
 
-      if (!prevLink) {
-        throw new Error('ProductLink not found');
-      }
+        if (!prevLink) {
+          throw new Error('ProductLink not found');
+        }
 
-      const updated = await tx
-        .update(productLinks)
-        .set({ ...modifier(prevLink) })
-        .where(eq(productLinks.id, linkId))
-        .returning();
+        const updated = await tx
+          .update(productLinks)
+          .set({ ...modifier(prevLink) })
+          .where(eq(productLinks.id, linkId))
+          .returning();
 
-      if (!updated[0]) {
-        throw new Error('ProductLink update failed');
-      }
+        if (!updated[0]) {
+          throw new Error('ProductLink update failed');
+        }
 
-      return this.mapper(updated[0]);
-    });
+        return this.mapper(updated[0]);
+      })
+      .then(result => {
+        this.productIdLoader.clearAll();
+        return result;
+      });
   }
 
   private mapper(schema: typeof productLinks.$inferSelect | typeof productLinks.$inferInsert): ProductLink {

--- a/libs/products/datasource/src/repositories/PostgresqlProductRepository.ts
+++ b/libs/products/datasource/src/repositories/PostgresqlProductRepository.ts
@@ -51,6 +51,9 @@ export class PostgresqlProductRepository implements ProductRepository {
       }
 
       return this.mapper(updated[0]);
+    }).then(result => {
+      this.publishedIdLoader.clearAll();
+      return result;
     });
   }
 
@@ -91,6 +94,9 @@ export class PostgresqlProductRepository implements ProductRepository {
         .returning();
 
       return inserted[0] ? this.mapper(inserted[0]) : null;
+    }).then(result => {
+      this.publishedIdLoader.clearAll();
+      return result;
     });
   }
 

--- a/libs/products/datasource/src/repositories/PostgresqlProductRepository.ts
+++ b/libs/products/datasource/src/repositories/PostgresqlProductRepository.ts
@@ -29,32 +29,34 @@ export class PostgresqlProductRepository implements ProductRepository {
   }
 
   updateById(id: string, modifier: (product: Product) => Product): Promise<Product> {
-    return this.db.transaction(async tx => {
-      const prevProduct = await tx
-        .select()
-        .from(products)
-        .where(eq(products.id, id))
-        .limit(1)
-        .then(rows => (rows[0] ? this.mapper(rows[0]) : null));
+    return this.db
+      .transaction(async tx => {
+        const prevProduct = await tx
+          .select()
+          .from(products)
+          .where(eq(products.id, id))
+          .limit(1)
+          .then(rows => (rows[0] ? this.mapper(rows[0]) : null));
 
-      if (!prevProduct) {
-        throw new Error('Product not found');
-      }
+        if (!prevProduct) {
+          throw new Error('Product not found');
+        }
 
-      const updated = await tx
-        .update(products)
-        .set({ ...modifier(prevProduct), updatedAt: new Date() })
-        .where(eq(products.id, id))
-        .returning();
-      if (!updated[0]) {
-        throw new Error('Product update failed');
-      }
+        const updated = await tx
+          .update(products)
+          .set({ ...modifier(prevProduct), updatedAt: new Date() })
+          .where(eq(products.id, id))
+          .returning();
+        if (!updated[0]) {
+          throw new Error('Product update failed');
+        }
 
-      return this.mapper(updated[0]);
-    }).then(result => {
-      this.publishedIdLoader.clearAll();
-      return result;
-    });
+        return this.mapper(updated[0]);
+      })
+      .then(result => {
+        this.publishedIdLoader.clearAll();
+        return result;
+      });
   }
 
   async findAllByBeforeIdAndLimit(limit: number, id?: string | undefined): Promise<Product[]> {
@@ -87,17 +89,19 @@ export class PostgresqlProductRepository implements ProductRepository {
   }
 
   async insert(values: Product): Promise<Product | null> {
-    return this.db.transaction(async tx => {
-      const inserted = await tx
-        .insert(products)
-        .values({ ...values })
-        .returning();
+    return this.db
+      .transaction(async tx => {
+        const inserted = await tx
+          .insert(products)
+          .values({ ...values })
+          .returning();
 
-      return inserted[0] ? this.mapper(inserted[0]) : null;
-    }).then(result => {
-      this.publishedIdLoader.clearAll();
-      return result;
-    });
+        return inserted[0] ? this.mapper(inserted[0]) : null;
+      })
+      .then(result => {
+        this.publishedIdLoader.clearAll();
+        return result;
+      });
   }
 
   async countPublishedAll(): Promise<number> {

--- a/libs/products/datasource/src/repositories/PostgresqlProductScreenshotRepository.ts
+++ b/libs/products/datasource/src/repositories/PostgresqlProductScreenshotRepository.ts
@@ -32,17 +32,22 @@ export class PostgresqlProductScreenshotRepository implements ProductScreenshotR
   }
 
   insert(productScreenshot: ProductScreenshot): Promise<ProductScreenshot> {
-    return this.db.transaction(async (tx) => {
-      const inserted = await tx
-        .insert(productScreenshots)
-        .values(productScreenshot)
-        .returning();
+    return this.db
+      .transaction(async (tx) => {
+        const inserted = await tx
+          .insert(productScreenshots)
+          .values(productScreenshot)
+          .returning();
 
-      if (!inserted[0]) {
-        throw new Error("Failed to insert product screenshot");
-      }
-      return inserted[0];
-    });
+        if (!inserted[0]) {
+          throw new Error("Failed to insert product screenshot");
+        }
+        return inserted[0];
+      })
+      .then((result) => {
+        this.productIdLoader.clearAll();
+        return result;
+      });
   }
 
   async findManyByProductIdSortByPriorityDesc(
@@ -65,5 +70,6 @@ export class PostgresqlProductScreenshotRepository implements ProductScreenshotR
     await this.db
       .delete(productScreenshots)
       .where(eq(productScreenshots.id, id));
+    this.productIdLoader.clearAll();
   }
 }

--- a/libs/products/datasource/src/repositories/PostgresqlProductScreenshotRepository.ts
+++ b/libs/products/datasource/src/repositories/PostgresqlProductScreenshotRepository.ts
@@ -1,15 +1,12 @@
-import {
-  ProductScreenshot,
-  ProductScreenshotRepository,
-} from "@darun/products-domain";
-import { ProductScreenshotRepositoryToken } from "@darun/products-domain";
-import { Drizzle } from "@darun/provider-database";
-import { DrizzleToken } from "@darun/provider-database";
-import DataLoader from "dataloader";
-import { eq, inArray } from "drizzle-orm";
-import { groupBy } from "es-toolkit";
-import { Inject, Service } from "typedi";
-import { productScreenshots } from "../entities/ProductScreenshotsSchema";
+import { ProductScreenshot, ProductScreenshotRepository } from '@darun/products-domain';
+import { ProductScreenshotRepositoryToken } from '@darun/products-domain';
+import { Drizzle } from '@darun/provider-database';
+import { DrizzleToken } from '@darun/provider-database';
+import DataLoader from 'dataloader';
+import { eq, inArray } from 'drizzle-orm';
+import { groupBy } from 'es-toolkit';
+import { Inject, Service } from 'typedi';
+import { productScreenshots } from '../entities/ProductScreenshotsSchema';
 
 @Service(ProductScreenshotRepositoryToken)
 export class PostgresqlProductScreenshotRepository implements ProductScreenshotRepository {
@@ -22,54 +19,43 @@ export class PostgresqlProductScreenshotRepository implements ProductScreenshotR
           .from(productScreenshots)
           .where(inArray(productScreenshots.productId, [...productIds]));
 
-        const groupByDocs = groupBy(docs, (doc) => doc.productId);
-        return productIds.map((productId) => groupByDocs[productId] || []);
+        const groupByDocs = groupBy(docs, doc => doc.productId);
+        return productIds.map(productId => groupByDocs[productId] || []);
       },
       {
         cache: true,
-      },
+      }
     );
   }
 
   insert(productScreenshot: ProductScreenshot): Promise<ProductScreenshot> {
     return this.db
-      .transaction(async (tx) => {
-        const inserted = await tx
-          .insert(productScreenshots)
-          .values(productScreenshot)
-          .returning();
+      .transaction(async tx => {
+        const inserted = await tx.insert(productScreenshots).values(productScreenshot).returning();
 
         if (!inserted[0]) {
-          throw new Error("Failed to insert product screenshot");
+          throw new Error('Failed to insert product screenshot');
         }
         return inserted[0];
       })
-      .then((result) => {
+      .then(result => {
         this.productIdLoader.clearAll();
         return result;
       });
   }
 
-  async findManyByProductIdSortByPriorityDesc(
-    productId: string,
-  ): Promise<ProductScreenshot[]> {
+  async findManyByProductIdSortByPriorityDesc(productId: string): Promise<ProductScreenshot[]> {
     return this.productIdLoader.load(productId);
   }
 
   async findById(id: string): Promise<ProductScreenshot | null> {
-    const result = await this.db
-      .select()
-      .from(productScreenshots)
-      .where(eq(productScreenshots.id, id))
-      .limit(1);
+    const result = await this.db.select().from(productScreenshots).where(eq(productScreenshots.id, id)).limit(1);
 
     return result[0] ?? null;
   }
 
   async deleteById(id: string): Promise<void> {
-    await this.db
-      .delete(productScreenshots)
-      .where(eq(productScreenshots.id, id));
+    await this.db.delete(productScreenshots).where(eq(productScreenshots.id, id));
     this.productIdLoader.clearAll();
   }
 }

--- a/libs/products/datasource/vitest.config.ts
+++ b/libs/products/datasource/vitest.config.ts
@@ -4,6 +4,9 @@ export default defineConfig({
   test: {
     passWithNoTests: true,
     include: ['src/**/*.test.ts'],
+    env: {
+      VOTE_IP_SALT: 'test-salt',
+    },
     coverage: {
       provider: 'v8',
     },

--- a/libs/products/datasource/vitest.config.ts
+++ b/libs/products/datasource/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    passWithNoTests: true,
+    include: ['src/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+    },
+  },
+});

--- a/libs/recommendation/datasource/package.json
+++ b/libs/recommendation/datasource/package.json
@@ -6,7 +6,7 @@
   "types": "./src/index.ts",
   "scripts": {
     "lint": "eslint **/*.ts*",
-    "test": "echo 1",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/libs/recommendation/datasource/src/__tests__/PostgresqlAlternativeProductRepository.test.ts
+++ b/libs/recommendation/datasource/src/__tests__/PostgresqlAlternativeProductRepository.test.ts
@@ -1,0 +1,93 @@
+import { AlternativeProduct } from '@darun/recommendation-domain';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PostgresqlAlternativeProductRepository } from '../repositories/PostgresqlAlternativeProductRepository';
+
+const mockClearAll = vi.fn();
+const mockLoad = vi.fn();
+
+vi.mock('dataloader', () => ({
+  default: function () {
+    return { load: mockLoad, clearAll: mockClearAll };
+  },
+}));
+
+describe('PostgresqlAlternativeProductRepository', () => {
+  let repository: PostgresqlAlternativeProductRepository;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    const mockTxDeleteWhere = vi.fn().mockResolvedValue({ count: 2 });
+    const mockTxReturning = vi
+      .fn()
+      .mockResolvedValue([{ id: 'new-1', productId: 'p1', alternativeProductId: 'alt-1' }]);
+
+    const mockTx = {
+      delete: vi.fn(() => ({ where: mockTxDeleteWhere })),
+      insert: vi.fn(() => ({
+        values: vi.fn(() => ({
+          returning: mockTxReturning,
+        })),
+      })),
+    };
+
+    const mockDb = {
+      transaction: vi.fn(async (fn: (tx: unknown) => unknown) => fn(mockTx)),
+    };
+
+    repository = new PostgresqlAlternativeProductRepository(mockDb as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+  });
+
+  describe('deleteMany', () => {
+    it('should call productIdLoader.clearAll() after deletion', async () => {
+      const alternatives = [
+        new AlternativeProduct({
+          id: '1',
+          productId: 'p1',
+          alternativeProductId: 'alt-1',
+        }),
+        new AlternativeProduct({
+          id: '2',
+          productId: 'p1',
+          alternativeProductId: 'alt-2',
+        }),
+      ];
+
+      await repository.deleteMany(alternatives);
+
+      expect(mockClearAll).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('createMany', () => {
+    it('should call productIdLoader.clearAll() after creating alternatives', async () => {
+      const alternatives = [
+        new AlternativeProduct({
+          productId: 'p1',
+          alternativeProductId: 'alt-1',
+        }),
+        new AlternativeProduct({
+          productId: 'p2',
+          alternativeProductId: 'alt-2',
+        }),
+      ];
+
+      await repository.createMany(alternatives);
+
+      expect(mockClearAll).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('create', () => {
+    it('should call productIdLoader.clearAll() after creating a single alternative', async () => {
+      const alternative = new AlternativeProduct({
+        productId: 'p1',
+        alternativeProductId: 'alt-1',
+      });
+
+      await repository.create(alternative);
+
+      expect(mockClearAll).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/libs/recommendation/datasource/src/repositories/PostgresqlAlternativeProductRepository.ts
+++ b/libs/recommendation/datasource/src/repositories/PostgresqlAlternativeProductRepository.ts
@@ -29,45 +29,51 @@ export class PostgresqlAlternativeProductRepository implements AlternativeProduc
   }
 
   deleteMany(removedAlternatives: AlternativeProduct[]): Promise<boolean> {
-    return this.db.transaction(async tx => {
-      const result = await tx.delete(alternativeProducts).where(
-        inArray(
-          alternativeProducts.id,
-          removedAlternatives.map(p => p.id)
-        )
-      );
-      return result.count === removedAlternatives.length;
-    }).then(result => {
-      this.productIdLoader.clearAll();
-      return result;
-    });
+    return this.db
+      .transaction(async tx => {
+        const result = await tx.delete(alternativeProducts).where(
+          inArray(
+            alternativeProducts.id,
+            removedAlternatives.map(p => p.id)
+          )
+        );
+        return result.count === removedAlternatives.length;
+      })
+      .then(result => {
+        this.productIdLoader.clearAll();
+        return result;
+      });
   }
   createMany(newAlternatives: AlternativeProduct[]): Promise<AlternativeProduct[]> {
-    return this.db.transaction(async tx => {
-      return tx.insert(alternativeProducts).values(newAlternatives).returning();
-    }).then(result => {
-      this.productIdLoader.clearAll();
-      return result;
-    });
+    return this.db
+      .transaction(async tx => {
+        return tx.insert(alternativeProducts).values(newAlternatives).returning();
+      })
+      .then(result => {
+        this.productIdLoader.clearAll();
+        return result;
+      });
   }
   create(data: AlternativeProduct): Promise<AlternativeProduct> {
-    return this.db.transaction(async tx => {
-      const inserted = await tx
-        .insert(alternativeProducts)
-        .values({ ...data })
-        .returning();
+    return this.db
+      .transaction(async tx => {
+        const inserted = await tx
+          .insert(alternativeProducts)
+          .values({ ...data })
+          .returning();
 
-      const createdAlternative = inserted[0];
+        const createdAlternative = inserted[0];
 
-      if (!createdAlternative) {
-        throw new Error('failed to create alternative product.');
-      }
+        if (!createdAlternative) {
+          throw new Error('failed to create alternative product.');
+        }
 
-      return createdAlternative;
-    }).then(result => {
-      this.productIdLoader.clearAll();
-      return result;
-    });
+        return createdAlternative;
+      })
+      .then(result => {
+        this.productIdLoader.clearAll();
+        return result;
+      });
   }
 
   async findManyByProductId(productId: string): Promise<AlternativeProduct[]> {

--- a/libs/recommendation/datasource/src/repositories/PostgresqlAlternativeProductRepository.ts
+++ b/libs/recommendation/datasource/src/repositories/PostgresqlAlternativeProductRepository.ts
@@ -37,11 +37,17 @@ export class PostgresqlAlternativeProductRepository implements AlternativeProduc
         )
       );
       return result.count === removedAlternatives.length;
+    }).then(result => {
+      this.productIdLoader.clearAll();
+      return result;
     });
   }
   createMany(newAlternatives: AlternativeProduct[]): Promise<AlternativeProduct[]> {
     return this.db.transaction(async tx => {
       return tx.insert(alternativeProducts).values(newAlternatives).returning();
+    }).then(result => {
+      this.productIdLoader.clearAll();
+      return result;
     });
   }
   create(data: AlternativeProduct): Promise<AlternativeProduct> {
@@ -58,6 +64,9 @@ export class PostgresqlAlternativeProductRepository implements AlternativeProduc
       }
 
       return createdAlternative;
+    }).then(result => {
+      this.productIdLoader.clearAll();
+      return result;
     });
   }
 

--- a/libs/recommendation/datasource/vitest.config.ts
+++ b/libs/recommendation/datasource/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    passWithNoTests: true,
+    include: ['src/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+    },
+  },
+});


### PR DESCRIPTION
## Description

5개 product-related PostgreSQL repository에서 mutation(insert/update/delete) 후 DataLoader cache를 clear하지 않아 수정 직후 조회가 오래된 데이터를 반환하는 버그 수정.

### 변경 사항

**5개 Repository 수정 — 각 mutation 후 cache.clearAll() 호출 추가:**
- `PostgresqlProductRepository`: `publishedIdLoader.clearAll()` (insert/updateById)
- `PostgresqlProductScreenshotRepository`: `productIdLoader.clearAll()` (insert/deleteById)
- `PostgresqlProductFeatureRepository`: `productIdLoader.clearAll()` (insert/updateById)
- `PostgresqlProductLinkRepository`: `productIdLoader.clearAll()` (insert/updateById)
- `PostgresqlAlternativeProductRepository`: `productIdLoader.clearAll()` (deleteMany/createMany/create)

**11개 mutation 메서드**에 대해 모두 cache.clearAll() 적용. transaction `.then()` 체인에서 호출되어 rollback 시 불필요한 무효화 방지.

### 테스트
- 4개 테스트 파일, 13개 테스트 케이스 (mock 기반, DataLoader.clearAll spy 검증)
- `pnpm test`: 62 tasks, 0 failures
- `pnpm typecheck`: 65 tasks, 0 errors

### 변경 파일 (13개)
- 5개 repository 파일 (수정)
- 4개 테스트 파일 (신규)
- 2개 vitest.config.ts (신규)
- 2개 package.json (test script 변경)

Closes: —