### PR TITLE
fix(graphql-api): unblock prod deploy tsconfig parse for lambda esbuild

### DIFF
--- a/apps/graphql-api/esbuild.plugins.js
+++ b/apps/graphql-api/esbuild.plugins.js
@@ -1,11 +1,13 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports */
 const { esbuildDecorators } = require('@kang-heewon/esbuild-plugin-typescript-decorators');
 const { sentryEsbuildPlugin } = require('@sentry/esbuild-plugin');
 
 const IS_LOCAL = process.env['INFRA_ENV'] === 'local';
 
 module.exports = [
-  esbuildDecorators({}),
+  esbuildDecorators({
+    tsconfig: 'tsconfig.lambda.json',
+  }),
   sentryEsbuildPlugin({
     authToken: process.env.SENTRY_AUTH_TOKEN,
     org: 'croco',

--- a/apps/graphql-api/tsconfig.lambda.json
+++ b/apps/graphql-api/tsconfig.lambda.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "types": ["node"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "target": "es2017",
+    "lib": ["es2017"],
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "strict": true,
+    "strictPropertyInitialization": false,
+    "skipLibCheck": true,
+    "skipDefaultLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- Production Deploy still fails after reflect-metadata packaging fix
- `@kang-heewon/esbuild-plugin-typescript-decorators` uses TypeScript 4.9 and rejects `module: preserve` from the shared base config
- Point the plugin at a standalone `tsconfig.lambda.json` with CommonJS settings

## Test plan
- [ ] Production Deploy succeeds
- [ ] `POST https://api.darun.io/graphql` `{ __typename }` returns data
- [ ] Homepage loads without error boundary


Made with [Cursor](https://cursor.com)