### PR TITLE
fix(graphql-api): inline reflect-metadata for Lambda cold start

### DIFF
--- a/apps/graphql-api/esbuild.plugins.js
+++ b/apps/graphql-api/esbuild.plugins.js
@@ -1,10 +1,22 @@
 /* eslint-disable @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports */
+const fs = require('fs');
 const { esbuildDecorators } = require('@kang-heewon/esbuild-plugin-typescript-decorators');
 const { sentryEsbuildPlugin } = require('@sentry/esbuild-plugin');
 
 const IS_LOCAL = process.env['INFRA_ENV'] === 'local';
+const reflectMetadataSource = fs.readFileSync(require.resolve('reflect-metadata'), 'utf8');
 
 module.exports = [
+  {
+    name: 'inline-reflect-metadata',
+    setup(build) {
+      const existingBanner = build.initialOptions.banner?.js ?? '';
+      build.initialOptions.banner = {
+        ...build.initialOptions.banner,
+        js: `${reflectMetadataSource}\n${existingBanner}`,
+      };
+    },
+  },
   esbuildDecorators({
     tsconfig: 'tsconfig.lambda.json',
   }),

--- a/apps/graphql-api/serverless.yaml
+++ b/apps/graphql-api/serverless.yaml
@@ -17,17 +17,12 @@ custom:
   esbuild:
     bundle: true
     exclude: ["class-validator"]
-    external:
-      - reflect-metadata
-    packager: pnpm
     minify: true
     keepNames: true
     sourcemap: true
     sourcesContent: false
     treeShaking: true
     ignoreAnnotations: true
-    banner:
-      js: "require('reflect-metadata');"
     plugins: esbuild.plugins.js
     watch:
       patterns:


### PR DESCRIPTION
## Summary
- Prod deploy succeeded but API still 500 with `Cannot find module 'reflect-metadata'`
- Package inspection showed `external`/`packager: pnpm` did not add `node_modules/reflect-metadata` to the zip
- Inline `reflect-metadata` source into the esbuild banner so cold start no longer depends on packaged node_modules

## Test plan
- [ ] Production Deploy succeeds
- [ ] Deployed zip bundle head contains Reflect polyfill, not `require('reflect-metadata')`
- [ ] `POST https://api.darun.io/graphql` `{ __typename }` returns data
- [ ] Homepage loads


Made with [Cursor](https://cursor.com)