### PR TITLE
fix(graphql-api): wrap inlined reflect-metadata in IIFE

### DIFF
--- a/apps/graphql-api/esbuild.plugins.js
+++ b/apps/graphql-api/esbuild.plugins.js
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports */
+const fs = require('fs');
 const { esbuildDecorators } = require('@kang-heewon/esbuild-plugin-typescript-decorators');
 const { sentryEsbuildPlugin } = require('@sentry/esbuild-plugin');
-const fs = require('fs');
 
 const IS_LOCAL = process.env['INFRA_ENV'] === 'local';
 const reflectMetadataSource = fs.readFileSync(require.resolve('reflect-metadata'), 'utf8');
@@ -13,7 +13,7 @@ module.exports = [
       const existingBanner = build.initialOptions.banner?.js ?? '';
       build.initialOptions.banner = {
         ...build.initialOptions.banner,
-        js: `${reflectMetadataSource}\n${existingBanner}`,
+        js: `(function () {\n${reflectMetadataSource}\n})();\n${existingBanner}`,
       };
     },
   },


### PR DESCRIPTION
## Summary
- Inlined Reflect.js leaked `var Reflect` into CommonJS module scope
- That shadowed native `Reflect.ownKeys` and crashed Lambda init
- Wrap the polyfill in an IIFE so it only installs metadata on globalThis

## Test plan
- [ ] Deploy succeeds
- [ ] Lambda invoke `{ __typename }` returns GraphQL JSON
- [ ] Homepage loads


Made with [Cursor](https://cursor.com)