### PR TITLE
chore: temporary Lambda log fetch for post-deploy diagnosis

### DIFF
--- a/.github/workflows/DebugLambdaLogs.yaml
+++ b/.github/workflows/DebugLambdaLogs.yaml
@@ -1,0 +1,40 @@
+name: Debug Lambda Logs
+
+on:
+  workflow_dispatch:
+
+jobs:
+  fetch-logs:
+    runs-on: ubuntu-latest
+    environment:
+      name: prod-graphql
+    steps:
+      - uses: croco-dev/aws-profile-action@v1.3
+        with:
+          profile: darun
+          region: ap-northeast-2
+          access-key: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          secret-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      - name: Inspect prod after deploy
+        env:
+          AWS_PROFILE: darun
+          AWS_DEFAULT_REGION: ap-northeast-2
+        run: |
+          set -euo pipefail
+          FN=graphql-api-prod-graphql
+          GROUP=/aws/lambda/$FN
+
+          echo "=== function meta ==="
+          aws lambda get-function-configuration --function-name "$FN" --query '{LastModified:LastModified,CodeSize:CodeSize,Runtime:Runtime,Handler:Handler}' --output json
+
+          echo "=== invoke ==="
+          aws lambda invoke --function-name "$FN" --cli-binary-format raw-in-base64-out --payload '{"httpMethod":"POST","path":"/graphql","headers":{"content-type":"application/json"},"body":"{\"query\":\"{ __typename }\"}"}' /tmp/out.json >/tmp/invoke-meta.json
+          cat /tmp/invoke-meta.json
+          echo
+          cat /tmp/out.json
+          echo
+
+          echo "=== recent ERROR logs ==="
+          START=$(($(date +%s)*1000-1800000))
+          aws logs filter-log-events --log-group-name "$GROUP" --start-time "$START" --filter-pattern '?ERROR ?Error ?TypeError ?Runtime ?Cannot ?Unhandled' --limit 30 --output json | python3 -c 'import json,sys; d=json.load(sys.stdin);
+[print(e.get("message","")) for e in d.get("events",[])]'


### PR DESCRIPTION
## Summary
- Temporary workflow to inspect prod GraphQL Lambda invoke/errors after #319 still returns API Gateway 500.

## Test plan
- [ ] workflow_dispatch succeeds and prints recent ERROR logs


Made with [Cursor](https://cursor.com)