### PR TITLE
Connect api.darun.io to SST API via existing domain name

### DIFF
--- a/apps/graphql-api/sst.config.ts
+++ b/apps/graphql-api/sst.config.ts
@@ -42,10 +42,16 @@ export default $config({
     });
 
     const api = new sst.aws.ApiGatewayV2('GraphqlApi', {
+      domain: {
+        nameId: 'api.darun.io',
+      },
       accessLog: { retention: '1 week' },
-      cors: false,
+      cors: {
+        allowOrigins: ['https://www.darun.io', 'https://admin.darun.io', 'https://visual.darun.io'],
+        allowMethods: ['GET', 'POST'],
+        allowHeaders: ['authorization', 'content-type'],
+      },
     });
-
     api.route('POST /graphql', fn.arn);
     api.route('GET /graphql', fn.arn);
 


### PR DESCRIPTION
## Summary

기존 API Gateway custom domain name(`api.darun.io`)을 SST `nameId` 옵션으로 재사용한다. SST가 새 API Gateway에 API mapping을 생성하고, Cloudflare CNAME과 ACM 인증서는 그대로 유지된다.

## Changes

- `sst.config.ts`: `domain: { nameId: 'api.darun.io' }` 추가
- `sst.config.ts`: CORS 설정 추가 (기존 Serverless API와 동일: `www.darun.io`, `admin.darun.io`, `visual.darun.io`)
- Deploy.yaml에서 Cloudflare secret 제거 (불필요)

## 동작 방식

```
Cloudflare api.darun.io CNAME
  → d-2x9ijx8w6e.execute-api... (기존 API Gateway domain name, 유지)
    → API mapping (SST가 새 API y666hj1ksb로 재매핑)
``

SST는 `nameId`로 지정된 기존 domain name에 새 API mapping을 추가한다. 기존 ACM 인증서, Cloudflare DNS 설정은 변경되지 않는다.

## 주의사항

배포 후 기존 Serverless 스택(`prod-graphql-api`)을 삭제하면 domain name도 같이 삭제될 수 있다. domain name을 Serverless 스택에서 분리한 후 삭제해야 한다.