### PR TITLE
Add VOTE_IP_SALT to Lambda environment config

### DIFF
--- a/apps/graphql-api/sst.config.ts
+++ b/apps/graphql-api/sst.config.ts
@@ -42,10 +42,16 @@ export default $config({
     });
 
     const api = new sst.aws.ApiGatewayV2('GraphqlApi', {
+      domain: {
+        nameId: 'api.darun.io',
+      },
       accessLog: { retention: '1 week' },
-      cors: false,
+      cors: {
+        allowOrigins: ['https://www.darun.io', 'https://admin.darun.io', 'https://visual.darun.io'],
+        allowMethods: ['GET', 'POST'],
+        allowHeaders: ['authorization', 'content-type'],
+      },
     });
-
     api.route('POST /graphql', fn.arn);
     api.route('GET /graphql', fn.arn);
 

--- a/apps/graphql-api/sst.config.ts
+++ b/apps/graphql-api/sst.config.ts
@@ -29,6 +29,7 @@ export default $config({
       CLOUDINARY_API_SECRET: process.env.CLOUDINARY_API_SECRET!,
       OPEN_ROUTER_API_KEY: process.env.OPEN_ROUTER_API_KEY!,
       CURSOR_SIGNATURE_SECRET: process.env.CURSOR_SIGNATURE_SECRET!,
+      VOTE_IP_SALT: process.env.VOTE_IP_SALT!,
     };
 
     const fn = new sst.aws.Function('GraphqlHandler', {


### PR DESCRIPTION
## Problem

SST 배포 후 Lambda가 모든 요청에서 500 Internal Server Error 반환.

원인: trunk에서 `VOTE_IP_SALT`가 `environment.ts`의 `requireEnv`로 추가되었지만, `sst.config.ts`의 Lambda `environment` 객체에 누락되어 Lambda가 `AssertionError: VOTE_IP_SALT not provided`로 크래시.

## Fix

`sst.config.ts` environment 객체에 `VOTE_IP_SALT: process.env.VOTE_IP_SALT!` 추가.

Deploy.yaml에는 이미 `VOTE_IP_SALT: ${{ secrets.VOTE_IP_SALT }}`가 설정되어 있음.