### PR TITLE
Add allowCredentials to CORS config

### DIFF
--- a/apps/graphql-api/sst.config.ts
+++ b/apps/graphql-api/sst.config.ts
@@ -51,6 +51,7 @@ export default $config({
         allowOrigins: ['https://www.darun.io', 'https://admin.darun.io', 'https://visual.darun.io'],
         allowMethods: ['GET', 'POST'],
         allowHeaders: ['authorization', 'content-type'],
+        allowCredentials: true,
       },
     });
     api.route('POST /graphql', fn.arn);


### PR DESCRIPTION
## Problem

프론트엔드(`www.darun.io`)에서 `credentials: 'include'`로 API 요청 시 CORS 에러:

```
The value of the 'Access-Control-Allow-Credentials' header in the response is ''
which must be 'true' when the request's credentials mode is 'include'.
```

이전 Serverless API에는 `AllowCredentials: true`가 설정되어 있었으나 SST 마이그레이션 시 누락.

## Fix

`sst.config.ts` CORS 설정에 `allowCredentials: true` 추가.