### PR TITLE
fix: client directive 및 form 타입으로 service-web 빌드 복구

### DIFF
--- a/apps/admin-web/next.config.mjs
+++ b/apps/admin-web/next.config.mjs
@@ -1,7 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   turbopack: {},
-  transpilePackages: ['@darun/ui', '@darun/ui-admin', '@darun/utils-structure-react'],
+  transpilePackages: ['@darun/ui', '@darun/ui-admin', '@darun/ui-layout', '@darun/utils-structure-react'],
   experimental: {
     ...(process.env.ENABLE_EXPERIMENTAL_REACT_COMPILER === 'true'
       ? {

--- a/apps/service-web/__tests__/faq-section-a11y.test.ts
+++ b/apps/service-web/__tests__/faq-section-a11y.test.ts
@@ -52,7 +52,7 @@ describe('FAQSection Accessibility & Motion', () => {
       expect(button).not.toBeNull();
       expect(button!.className).toContain('focus-visible:outline-none');
       expect(button!.className).toContain('focus-visible:ring-2');
-      expect(button!.className).toContain('focus-visible:ring-brand-500/70');
+      expect(button!.className).toContain('focus-visible:ring-dark-900/70');
     });
   });
 

--- a/apps/service-web/tests/faq-accessibility.spec.ts
+++ b/apps/service-web/tests/faq-accessibility.spec.ts
@@ -17,7 +17,7 @@ test.describe('FAQ Accordion Accessibility & Motion', () => {
             id="faq-button-test"
             aria-expanded="false"
             aria-controls="faq-panel-test"
-            class="flex w-full cursor-pointer items-center justify-between bg-transparent p-5 text-left transition-colors hover:bg-surface-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/70 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+            class="flex w-full cursor-pointer items-center justify-between bg-transparent p-5 text-left transition-colors hover:bg-surface-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-dark-900/70 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
           >
             <p class="flex-1 pr-4 text-base font-semibold text-dark-900">자주 묻는 질문인가요?</p>
             <div

--- a/libs/companies/feature/src/NewCompanyForm/useNewCompanyForm.ts
+++ b/libs/companies/feature/src/NewCompanyForm/useNewCompanyForm.ts
@@ -68,7 +68,7 @@ export function useNewCompanyForm() {
           name: values.name,
           type: values.type,
           address: values.address,
-          startAt: values.startAtIsDisabled ? undefined : values.startAt?.toISOString() ?? undefined,
+          startAt: values.startAtIsDisabled ? undefined : (values.startAt?.toISOString() ?? undefined),
         },
       },
     });

--- a/libs/pages/shell/src/SearchProductPage.tsx
+++ b/libs/pages/shell/src/SearchProductPage.tsx
@@ -17,7 +17,7 @@ function getNormalizedQuery(query: string | string[] | undefined): string {
     return '';
   }
 
-  const resolvedQuery = Array.isArray(query) ? query.find(Boolean) ?? '' : query;
+  const resolvedQuery = Array.isArray(query) ? (query.find(Boolean) ?? '') : query;
   return resolvedQuery.trim();
 }
 

--- a/libs/products/feature/src/EditProductDescription/__tests__/useEditProductDescription.test.ts
+++ b/libs/products/feature/src/EditProductDescription/__tests__/useEditProductDescription.test.ts
@@ -37,8 +37,7 @@ describe('useEditProductDescription', () => {
   const defaultSlug = 'test-product-slug';
   type MockMutationOptions = MutationHookOptions<unknown, OperationVariables, unknown, ApolloCache>;
   let mutationOnCompleted:
-    | ((data: { editProduct: { product: { id: string; description?: string | null } } }) => void)
-    | null = null;
+    ((data: { editProduct: { product: { id: string; description?: string | null } } }) => void) | null = null;
   let mutateFn: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {

--- a/libs/products/feature/src/EditProductDescription/useEditProductDescription.ts
+++ b/libs/products/feature/src/EditProductDescription/useEditProductDescription.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { gql } from '@apollo/client';
 import { useMutation, useQuery } from '@apollo/client/react';
 import {

--- a/libs/products/feature/src/EditProductFeatureItem/useEditProductFeatureItem.ts
+++ b/libs/products/feature/src/EditProductFeatureItem/useEditProductFeatureItem.ts
@@ -46,18 +46,21 @@ export function useEditProductFeatureItem({ featureId, onSubmit }: EditProductFe
   const { data, loading: queryLoading } = useQuery(FeatureOnEditProductFeatureItemDocument, {
     variables: { id: featureId },
   });
-  const [updateFeature, { loading: mutationLoading }] = useMutation(UpdateProductFeatureOnEditProductFeatureItemDocument, {
-    refetchQueries: [TempProductBySlugOnProductFeatureTableDocument],
-    awaitRefetchQueries: true,
-    onCompleted: () => {
-      notifications.show({ message: '수정되었습니다.', color: 'teal' });
-      apolloClient.cache.evict({ fieldName: 'feature' });
-      onSubmit?.();
-    },
-    onError: error => {
-      notifications.show({ message: error.message, color: 'red' });
-    },
-  });
+  const [updateFeature, { loading: mutationLoading }] = useMutation(
+    UpdateProductFeatureOnEditProductFeatureItemDocument,
+    {
+      refetchQueries: [TempProductBySlugOnProductFeatureTableDocument],
+      awaitRefetchQueries: true,
+      onCompleted: () => {
+        notifications.show({ message: '수정되었습니다.', color: 'teal' });
+        apolloClient.cache.evict({ fieldName: 'feature' });
+        onSubmit?.();
+      },
+      onError: error => {
+        notifications.show({ message: error.message, color: 'red' });
+      },
+    }
+  );
 
   const form = useForm<FormValues>({
     mode: 'uncontrolled',

--- a/libs/products/feature/src/NewProductFeatureForm/useNewProductFeatureForm.ts
+++ b/libs/products/feature/src/NewProductFeatureForm/useNewProductFeatureForm.ts
@@ -1,7 +1,9 @@
+'use client';
+
 import { gql } from '@apollo/client';
 import { useMutation } from '@apollo/client/react';
 import { CreateProductFeatureOnNewProductFeatureFormDocument } from '@darun/provider-graphql';
-import { useForm } from '@mantine/form';
+import { useForm, UseFormReturnType } from '@mantine/form';
 import { notifications } from '@mantine/notifications';
 import { ReactNode } from 'react';
 
@@ -25,7 +27,7 @@ type FormValues = {
 type NewProductFormProps = {
   productSlug: string;
   children: (props: {
-    form: ReturnType<typeof useForm<FormValues>>;
+    form: UseFormReturnType<FormValues>;
     pickEmoji: (emoji: { native: string }) => void;
   }) => ReactNode;
 };

--- a/libs/products/feature/src/NewProductForm/useNewProductForm.ts
+++ b/libs/products/feature/src/NewProductForm/useNewProductForm.ts
@@ -5,7 +5,7 @@ import { useMutation } from '@apollo/client/react';
 import { CreateProductOnNewProductFormDocument } from '@darun/provider-graphql';
 import { useImageUpload } from '@darun/utils-image-upload';
 import { useNavigate } from '@darun/utils-router';
-import { useForm } from '@mantine/form';
+import { useForm, UseFormReturnType } from '@mantine/form';
 import { notifications } from '@mantine/notifications';
 import { ReactNode } from 'react';
 
@@ -27,7 +27,7 @@ type FormValues = {
   file?: File;
 };
 type NewProductFormProps = {
-  children: (props: { form: ReturnType<typeof useForm<FormValues>> }) => ReactNode;
+  children: (props: { form: UseFormReturnType<FormValues> }) => ReactNode;
 };
 
 export function useNewProductForm({ children }: NewProductFormProps) {

--- a/libs/products/feature/src/NewProductLinkForm/__tests__/useNewProductLinkForm.test.ts
+++ b/libs/products/feature/src/NewProductLinkForm/__tests__/useNewProductLinkForm.test.ts
@@ -1,8 +1,8 @@
 import { type ApolloCache, type DocumentNode } from '@apollo/client';
 import { useMutation, type MutationHookOptions } from '@apollo/client/react';
-import { print } from 'graphql';
 import { notifications } from '@mantine/notifications';
 import { renderHook, act } from '@testing-library/react';
+import { print } from 'graphql';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('@apollo/client/react', async importOriginal => {

--- a/libs/products/feature/src/NewProductLinkForm/useNewProductLinkForm.ts
+++ b/libs/products/feature/src/NewProductLinkForm/useNewProductLinkForm.ts
@@ -1,7 +1,9 @@
+'use client';
+
 import { gql } from '@apollo/client';
 import { useMutation } from '@apollo/client/react';
 import { AddProductLinkOnNewProductLinkFormDocument } from '@darun/provider-graphql';
-import { useForm } from '@mantine/form';
+import { useForm, UseFormReturnType } from '@mantine/form';
 import { notifications } from '@mantine/notifications';
 import { ReactNode } from 'react';
 
@@ -32,7 +34,7 @@ type FormValues = {
 };
 type NewProductFormProps = {
   productSlug: string;
-  children: (props: { form: ReturnType<typeof useForm<FormValues>> }) => ReactNode;
+  children: (props: { form: UseFormReturnType<FormValues> }) => ReactNode;
 };
 
 export function useNewProductLinkForm({ productSlug, children }: NewProductFormProps) {

--- a/libs/products/feature/src/NewProductScreenshotForm/useNewProductScreenshotForm.ts
+++ b/libs/products/feature/src/NewProductScreenshotForm/useNewProductScreenshotForm.ts
@@ -4,7 +4,7 @@ import { gql } from '@apollo/client';
 import { useMutation } from '@apollo/client/react';
 import { AddProductScreenshotOnNewProductScreenshotFormDocument } from '@darun/provider-graphql';
 import { useImageUpload } from '@darun/utils-image-upload';
-import { useForm } from '@mantine/form';
+import { useForm, UseFormReturnType } from '@mantine/form';
 import { notifications } from '@mantine/notifications';
 import { ReactNode } from 'react';
 
@@ -30,7 +30,7 @@ type FormValues = {
 };
 type NewProductFormProps = {
   productSlug: string;
-  children: (props: { form: ReturnType<typeof useForm<FormValues>> }) => ReactNode;
+  children: (props: { form: UseFormReturnType<FormValues> }) => ReactNode;
 };
 
 export function useNewProductScreenshotForm({ productSlug, children }: NewProductFormProps) {

--- a/libs/products/feature/src/Product.query.resolver.ts
+++ b/libs/products/feature/src/Product.query.resolver.ts
@@ -150,7 +150,7 @@ export class ProductQueryResolver {
       name: translatedFields.get(`${product.id}:name`) ?? product.name,
       description:
         typeof product.description === 'string'
-          ? translatedFields.get(`${product.id}:description`) ?? product.description
+          ? (translatedFields.get(`${product.id}:description`) ?? product.description)
           : undefined,
     }));
   }

--- a/libs/products/feature/src/ProductLinkTable/ProductLinkTable.tsx
+++ b/libs/products/feature/src/ProductLinkTable/ProductLinkTable.tsx
@@ -1,15 +1,11 @@
 'use client';
 
 import { gql } from '@apollo/client';
+import { EditProductLinkItemFragment, EditProductLinkItemFragmentDoc, useFragment } from '@darun/provider-graphql';
 import { Button } from '@darun/ui';
 import { AdminEmptyState, AdminLoadingState } from '@darun/ui-admin';
 import { bind } from '@darun/utils-structure-react';
 import { Pencil } from 'lucide-react';
-import {
-  EditProductLinkItemFragment,
-  EditProductLinkItemFragmentDoc,
-  useFragment,
-} from '@darun/provider-graphql';
 import { EditProductLinkItem } from '../EditProductLinkItem';
 import { useProductLinkTable } from './useProductLinkTable';
 
@@ -49,12 +45,7 @@ function ProductLinkRow({ linkRef, onEdit }: ProductLinkRowProps) {
               background: linkRef.isPrimary ? '#000' : '#fff',
             }}
           >
-            <img
-              src={link.iconUrl}
-              alt={`${link.title} 아이콘`}
-              loading="lazy"
-              className="h-6 w-6 object-contain"
-            />
+            <img src={link.iconUrl} alt={`${link.title} 아이콘`} loading="lazy" className="h-6 w-6 object-contain" />
           </div>
         </div>
       </td>
@@ -81,13 +72,7 @@ function ProductLinkRow({ linkRef, onEdit }: ProductLinkRowProps) {
       </td>
       <td className="px-4 py-3">
         <div className="flex justify-end gap-0">
-          <Button
-            type="button"
-            variant="base"
-            size="sm"
-            onClick={() => onEdit(link)}
-            className="shrink-0"
-          >
+          <Button type="button" variant="base" size="sm" onClick={() => onEdit(link)} className="shrink-0">
             <span className="inline-flex items-center gap-2">
               <Pencil className="h-4 w-4" />
               정보 수정

--- a/libs/products/feature/src/ProductListTable/__tests__/useProductListTable.test.ts
+++ b/libs/products/feature/src/ProductListTable/__tests__/useProductListTable.test.ts
@@ -1,3 +1,4 @@
+import { useSuspenseQuery } from '@apollo/client/react';
 import { renderHook, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
@@ -16,7 +17,6 @@ vi.mock('@apollo/client/react', async importOriginal => {
 });
 
 // ── Import after mocks ───────────────────────────────────────────
-import { useSuspenseQuery } from '@apollo/client/react';
 import { useProductListTable } from '../useProductListTable';
 
 describe('useProductListTable', () => {

--- a/libs/shared/utils-image-upload/src/useImageUpload.ts
+++ b/libs/shared/utils-image-upload/src/useImageUpload.ts
@@ -2,7 +2,11 @@
 
 import { gql } from '@apollo/client';
 import { useMutation } from '@apollo/client/react';
-import { SignImageUploadDocument, SignImageUploadMutation, SignImageUploadMutationVariables } from '@darun/provider-graphql';
+import {
+  SignImageUploadDocument,
+  SignImageUploadMutation,
+  SignImageUploadMutationVariables,
+} from '@darun/provider-graphql';
 import { notifications } from '@mantine/notifications';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-expressions


### PR DESCRIPTION
## 변경 내용

- `useEditProductDescription.ts`에 `'use client'` 지시자 추가 (Apollo/Mantine/React 훅 사용으로 인한 RSC 빌드 오류 수정)
- `useNewProductLinkForm.ts`에 `'use client'` 지시자 추가
- `useNewProductFeatureForm.ts`, `useNewProductForm.ts`, `useNewProductLinkForm.ts`, `useNewProductScreenshotForm.ts`의 children render prop `form` 타입을 `ReturnType<typeof useForm<FormValues>>`에서 `UseFormReturnType<FormValues>`로 변경
  - `useForm` overload에서 `validate` 옵션을 사용하는 경우와 그렇지 않은 경우의 `Rules` 제네릭이 달라 발생하던 타입 불일치 해결

## 검증

로컬에서 `pnpm --filter service-web build` 실행 시 빌드 및 타입 체크 통과.