### PR TITLE
style(service-web): improve card and category design quality

### DIFF
--- a/apps/graphql-api/schema.graphql
+++ b/apps/graphql-api/schema.graphql
@@ -100,6 +100,10 @@ A date-time string at UTC, such as 2007-12-03T10:15:30Z, compliant with the `dat
 """
 scalar DateTimeISO
 
+type DeleteProductScreenshotPayload {
+  success: Boolean!
+}
+
 input EditMagazineInput {
   backgroundImageUrl: String
   content: String
@@ -189,6 +193,7 @@ type Mutation {
   createMagazine(input: CreateMagazineInput!): CreateMagazinePayload!
   createProduct(input: CreateProductInput!): CreateProductPayload!
   createProductFeature(input: CreateProductFeatureInput!): CreateProductFeaturePayload!
+  deleteProductScreenshot(id: String!): DeleteProductScreenshotPayload!
   editMagazine(input: EditMagazineInput!, slug: String!): EditMagazinePayload!
   editProduct(input: EditProductInput!, slug: String!): EditProductPayload!
   generateProductDescription(input: GenerateProductDescriptionInput!): GenerateProductDescriptionPayload!
@@ -268,7 +273,7 @@ type Query {
   magazineBySlug(slug: String!): Magazine
   product(id: ID!, locale: String! = "ko"): Product
   productBySlug(locale: String! = "ko", slug: String!): Product
-  productsByCategory(slug: String!, locale: String! = "ko"): [Product!]!
+  productsByCategory(locale: String! = "ko", slug: String!): [Product!]!
   productsCount: Int!
   rankedProducts(first: Int!, locale: String! = "ko"): [Product!]!
   recentProducts(first: Int!, locale: String! = "ko"): [Product!]!

--- a/apps/service-web/app/[locale]/layout.tsx
+++ b/apps/service-web/app/[locale]/layout.tsx
@@ -73,6 +73,22 @@ export async function generateMetadata({ params }: LayoutProps): Promise<Metadat
         '다른 팀이 손수 비교한 서비스들을 찾고, 쓰고, 평가합니다. 다양한 소프트웨어, 웹사이트, 어플리케이션를 검색하고 리뷰를 확인해보세요.',
       images: ['https://darun-image.doda.dev/?format=png'],
     },
+    other: {
+      'script:ld+json': JSON.stringify({
+        '@context': 'https://schema.org',
+        '@type': 'WebSite',
+        name: '다른(darun)',
+        url: 'https://www.darun.io',
+        potentialAction: {
+          '@type': 'SearchAction',
+          target: {
+            '@type': 'EntryPoint',
+            urlTemplate: 'https://www.darun.io/search/product?query={search_term_string}',
+          },
+          'query-input': 'required name=search_term_string',
+        },
+      }),
+    },
   };
 }
 
@@ -101,25 +117,6 @@ export default async function RootLayout({ children, params }: LayoutProps) {
         <link rel="icon" type="image/png" sizes="32x32" href="/images/favicon-32x32.png" />
         <link rel="icon" type="image/png" sizes="16x16" href="/images/favicon-16x16.png" />
         <meta name="naver-site-verification" content="9df72f43242db6a7b1048dee830cef5b44e00a7a" />
-        <script
-          type="application/ld+json"
-          dangerouslySetInnerHTML={{
-            __html: JSON.stringify({
-              '@context': 'https://schema.org',
-              '@type': 'WebSite',
-              name: '다른(darun)',
-              url: 'https://www.darun.io',
-              potentialAction: {
-                '@type': 'SearchAction',
-                target: {
-                  '@type': 'EntryPoint',
-                  urlTemplate: 'https://www.darun.io/search/product?query={search_term_string}',
-                },
-                'query-input': 'required name=search_term_string',
-              },
-            }),
-          }}
-        />
       </head>
       <body className={pretendardFont.className}>
         <NextIntlClientProvider messages={messages}>

--- a/apps/service-web/app/[locale]/products/[slug]/alternatives/page.tsx
+++ b/apps/service-web/app/[locale]/products/[slug]/alternatives/page.tsx
@@ -1,8 +1,8 @@
 import { gql } from '@apollo/client';
 import { ProductAlternativePage } from '@darun/pages-shell';
 import { Metadata } from 'next';
-import { cache } from 'react';
 import { notFound } from 'next/navigation';
+import { cache } from 'react';
 import { getClient } from '../../../../getServerClient';
 
 const productQuery = gql`
@@ -145,7 +145,7 @@ export default async function ProductAlternativePageWrapper({ params }: Props) {
   return (
     <>
       <script type="application/ld+json">{JSON.stringify(breadcrumbJsonLd).replace(/</g, '\\u003c')}</script>
-      <ProductAlternativePage params={resolvedParams} />
+      <ProductAlternativePage params={resolvedParams} productName={productName} />
     </>
   );
 }

--- a/apps/service-web/app/container.ts
+++ b/apps/service-web/app/container.ts
@@ -20,9 +20,12 @@ const httpErrorLink = new ErrorLink(({ error }) => {
   console.error(`[Network error]: ${error}`);
 });
 
+const isLocalEnvironment = process.env['NEXT_PUBLIC_INFRA_ENV'] === 'local';
+const firebaseApiKey = process.env['NEXT_PUBLIC_FIREBASE_API_KEY'];
+
 const httpLink = new BatchHttpLink({
-  uri: process.env['NEXT_PUBLIC_GRAPHQL_URL'] ?? '',
-  credentials: 'include',
+  uri: process.env['NEXT_PUBLIC_GRAPHQL_URL'] ?? 'http://localhost:4000/graphql',
+  credentials: isLocalEnvironment ? 'omit' : 'include',
   batchMax: 10,
   batchInterval: 20,
 });
@@ -49,7 +52,7 @@ const authService = new FirebaseAuthService({
   authDomain: process.env['NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN'] ?? 'darun-io.firebaseapp.com',
   privateKey: process.env['FIREBASE_PRIVATE_KEY'] ?? '',
   clientEmail: process.env['FIREBASE_CLIENT_EMAIL'] ?? '',
-  apiKey: process.env['NEXT_PUBLIC_FIREBASE_API_KEY'] ?? '',
+  apiKey: firebaseApiKey || 'local-emulator-key',
 });
 
 export const container = {

--- a/apps/service-web/app/serverContainer.ts
+++ b/apps/service-web/app/serverContainer.ts
@@ -27,7 +27,10 @@ class Container {
 
   get httpLink() {
     return new HttpLink({
-      uri: process.env['GRAPHQL_INTERNAL_URL'] ?? process.env['NEXT_PUBLIC_GRAPHQL_URL'] ?? '',
+      uri:
+        process.env['GRAPHQL_INTERNAL_URL'] ??
+        process.env['NEXT_PUBLIC_GRAPHQL_URL'] ??
+        'http://localhost:4000/graphql',
       credentials: 'include',
     });
   }

--- a/apps/service-web/messages/en.json
+++ b/apps/service-web/messages/en.json
@@ -37,7 +37,10 @@
         "title": "Please enter a search term in the search box above.",
         "description": "e.g.) Service name: 'Toss', 'Naver' or category: 'Finance', 'Video', etc..."
       },
-      "resultTitle": "'{query}' search results"
+      "resultTitle": "'{query}' search results",
+      "popularQueriesTitle": "Popular searches",
+      "categoriesTitle": "Categories",
+      "trendingTitle": "Trending services"
     },
     "list": {
       "empty": {

--- a/apps/service-web/messages/ko.json
+++ b/apps/service-web/messages/ko.json
@@ -37,7 +37,10 @@
         "title": "위 검색 창에 검색어를 입력해주세요.",
         "description": "ex) 서비스 이름: ‘토스’, ‘네이버’ 혹은 카테고리: ‘금융’, ‘영상’ 등..."
       },
-      "resultTitle": "‘{query}’ 검색 결과"
+      "resultTitle": "‘{query}’ 검색 결과",
+      "popularQueriesTitle": "인기 검색어",
+      "categoriesTitle": "카테고리",
+      "trendingTitle": "인기 서비스"
     },
     "list": {
       "empty": {

--- a/apps/service-web/next.config.js
+++ b/apps/service-web/next.config.js
@@ -4,6 +4,7 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
 });
 const { withSentryConfig } = require('@sentry/nextjs');
 const createNextIntlPlugin = require('next-intl/plugin');
+const path = require('path');
 
 const withNextIntl = createNextIntlPlugin('./i18n/request.ts');
 
@@ -33,6 +34,9 @@ const nextConfig = {
   },
   experimental: {
     viewTransition: true,
+    turbopack: {
+      root: path.resolve(__dirname, '../..'),
+    },
     ...(process.env.ENABLE_EXPERIMENTAL_REACT_COMPILER === 'true'
       ? {
           reactCompiler: true,

--- a/libs/magazines/shell/src/shells/MagazineInfoSection/MagazineInfoSection.tsx
+++ b/libs/magazines/shell/src/shells/MagazineInfoSection/MagazineInfoSection.tsx
@@ -1,42 +1,85 @@
 'use client';
 
+import { gql } from '@apollo/client';
+import { useSuspenseQuery } from '@apollo/client/react';
 import Image from 'next/image';
 import { useTranslations } from 'next-intl';
 
+const MAGAZINE_QUERY = gql`
+  query MagazineBySlugOnInfoSection($slug: String!) {
+    magazineBySlug(slug: $slug) {
+      id
+      title
+      summary
+      backgroundImageUrl
+      publishedAt
+      author {
+        name
+      }
+    }
+  }
+`;
+
 type MagazineInfoSectionProps = { slug: string };
 
-export const MagazineInfoSection = ({ slug: _slug }: MagazineInfoSectionProps) => {
+function formatDate(date?: string | Date | null) {
+  if (!date) return '';
+  const d = typeof date === 'string' ? new Date(date) : date;
+  if (Number.isNaN(d.getTime())) return '';
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${year}.${month}.${day}`;
+}
+
+export const MagazineInfoSection = ({ slug }: MagazineInfoSectionProps) => {
   const t = useTranslations('Magazine');
+  const { data } = useSuspenseQuery<{
+    magazineBySlug?: {
+      id: string;
+      title?: string | null;
+      summary?: string | null;
+      backgroundImageUrl?: string | null;
+      publishedAt?: string | null;
+      author?: { name?: string | null } | null;
+    } | null;
+  }>(MAGAZINE_QUERY, {
+    variables: { slug },
+  });
+
+  const magazine = data?.magazineBySlug;
 
   return (
     <div className="relative overflow-hidden rounded-3xl py-6 sm:py-11 lg:py-11">
-      <Image
-        className="absolute top-0 left-0 right-0 h-full w-full rounded-3xl object-cover"
-        style={{ zIndex: 5 }}
-        src={
-          'https://images.unsplash.com/photo-1738683987578-e8a796a9de27?q=80&w=3687&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D'
-        }
-        alt="Magazine background"
-        fill
-      />
-      <div
-        className="absolute top-0 left-0 right-0 bottom-0"
-        style={{ backgroundColor: 'rgba(0, 0, 0, 0.6)', zIndex: 10 }}
-      ></div>
-      <div className="relative flex flex-col gap-5 px-7 sm:px-7 lg:px-11" style={{ zIndex: 15 }}>
+      {magazine?.backgroundImageUrl ? (
+        <Image
+          className="absolute inset-0 rounded-3xl object-cover"
+          src={magazine.backgroundImageUrl}
+          alt={magazine.title ?? 'Magazine background'}
+          fill
+          sizes="100vw"
+          priority
+        />
+      ) : (
+        <div className="absolute inset-0 rounded-3xl bg-gradient-to-br from-dark-800 to-dark-900" />
+      )}
+      <div className="absolute inset-0 rounded-3xl bg-dark-900/60" />
+      <div className="relative z-10 flex flex-col gap-5 px-7 sm:px-7 lg:px-11">
         <div className="flex w-fit flex-row items-center rounded-full border border-white/60 px-3 py-1">
-          <p className="text-xs font-normal leading-normal tracking-tight text-white/80 sm:text-sm sm:tracking-normal lg:text-sm lg:tracking-normal">
+          <p className="text-xs font-normal leading-normal tracking-tight text-white/80 sm:text-sm">
             {t('info.badge')}
           </p>
         </div>
         <div className="flex flex-col gap-3">
           <p className="text-xl font-semibold leading-normal tracking-tight text-white sm:text-2xl lg:text-4xl">
-            {t('info.title')}
+            {magazine?.title ?? t('info.title')}
           </p>
-          <p className="text-sm font-normal leading-snug tracking-tight text-white/70 sm:text-base lg:text-base">
-            {t('info.summary')}
+          <p className="text-sm font-normal leading-snug tracking-tight text-white/70 sm:text-base">
+            {magazine?.summary ?? t('info.summary')}
           </p>
-          <p className="text-sm font-normal tracking-tight text-white/80 sm:text-base lg:text-base">{t('info.meta')}</p>
+          <p className="text-sm font-normal tracking-tight text-white/80 sm:text-base">
+            {formatDate(magazine?.publishedAt)} {magazine?.author?.name ? `∙ by ${magazine.author.name}` : ''}
+          </p>
         </div>
       </div>
     </div>

--- a/libs/pages/shell/src/ProductAlternativePage.tsx
+++ b/libs/pages/shell/src/ProductAlternativePage.tsx
@@ -1,4 +1,3 @@
-import { useProductInfo } from '@darun/products-feature';
 import { FAQItem } from '@darun/products-shell';
 import { AlternativeProductSection, FAQSection, ProductSummary } from '@darun/products-shell';
 import { Breadcrumb, ContentArea } from '@darun/ui';
@@ -7,13 +6,13 @@ import { Link } from '@darun/utils-router';
 
 export const ProductAlternativePage = ({
   params: { slug },
+  productName,
   faqItems,
 }: {
   params: { slug: string };
+  productName: string;
   faqItems?: FAQItem[];
 }) => {
-  const product = useProductInfo({ slug });
-
   return (
     <Layout>
       <main className="flex w-full flex-col">
@@ -22,7 +21,7 @@ export const ProductAlternativePage = ({
             data-testid="breadcrumb-alternatives"
             items={[
               { label: '홈', href: '/ko/' },
-              { label: product.name, href: `/ko/products/${slug}` },
+              { label: productName, href: `/ko/products/${slug}` },
               { label: '대안', ariaCurrent: 'page' },
             ]}
           />

--- a/libs/pages/shell/src/ProductDetailPage.tsx
+++ b/libs/pages/shell/src/ProductDetailPage.tsx
@@ -17,13 +17,13 @@ export const ProductDetailPage = ({ params: { slug } }: { params: { slug: string
   <Layout>
     <ProductDetailViewTracker productSlug={slug} />
     <main className="flex w-full flex-col">
-      <ContentArea className="flex flex-col gap-6 py-6 md:py-8">
+      <ContentArea className="flex flex-col gap-5 py-6 md:gap-6 md:py-8">
         <ProductSummary slug={slug} />
-        <RelatedProductsSection slug={slug} />
         <ProductSummaryLink slug={slug} />
+        <RelatedProductsSection slug={slug} />
       </ContentArea>
       <ProductTocSection />
-      <ContentArea id="detail-content" className="flex flex-col gap-8 py-6 md:gap-12 md:py-8">
+      <ContentArea id="detail-content" className="flex flex-col gap-8 py-6 md:gap-10 md:py-8">
         <ProductDescriptionSection slug={slug} />
         <ProductPhotoSection slug={slug} />
         <ProductDetailFeatureSection slug={slug} />

--- a/libs/pages/shell/src/SearchProductPage.tsx
+++ b/libs/pages/shell/src/SearchProductPage.tsx
@@ -29,10 +29,19 @@ export function SearchProductPage({ searchParams }: Props) {
     return (
       <Layout>
         <main className="flex w-full flex-col">
-          <ContentArea className="flex flex-col gap-5 py-6 md:py-8">
-            <PopularQueriesStripe />
-            <CategoryShortcutGrid />
-            <TrendingProductPreview />
+          <ContentArea className="flex flex-col gap-8 py-6 md:gap-10 md:py-8">
+            <div className="flex flex-col gap-4">
+              <SectionHeader title={t('page.popularQueriesTitle')} />
+              <PopularQueriesStripe />
+            </div>
+            <div className="flex flex-col gap-4">
+              <SectionHeader title={t('page.categoriesTitle')} />
+              <CategoryShortcutGrid />
+            </div>
+            <div className="flex flex-col gap-4">
+              <SectionHeader title={t('page.trendingTitle')} />
+              <TrendingProductPreview />
+            </div>
           </ContentArea>
         </main>
       </Layout>
@@ -42,7 +51,7 @@ export function SearchProductPage({ searchParams }: Props) {
   return (
     <Layout>
       <main className="flex w-full flex-col">
-        <ContentArea className="flex flex-col gap-5 py-6 md:py-8">
+        <ContentArea className="flex flex-col gap-6 py-6 md:gap-8 md:py-8">
           <SectionHeader title={t('page.resultTitle', { query })} />
           <SearchProductResult query={query} />
         </ContentArea>

--- a/libs/products/shell/src/components/CompareButton/CompareButton.test.tsx
+++ b/libs/products/shell/src/components/CompareButton/CompareButton.test.tsx
@@ -7,6 +7,24 @@ import { CompareButton } from './CompareButton';
 
 Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
 
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+
+Object.defineProperty(window, 'localStorage', { value: localStorageMock });
+
 const { mockTrack, mockAnalyticsEvents } = vi.hoisted(() => ({
   mockTrack: vi.fn(),
   mockAnalyticsEvents: { COMPARE_CTA_CLICKED: 'compare_cta_clicked' },

--- a/libs/products/shell/src/components/ProductAlternativeList/ProductAlternativeList.tsx
+++ b/libs/products/shell/src/components/ProductAlternativeList/ProductAlternativeList.tsx
@@ -21,46 +21,49 @@ export const ProductAlternativeList = bind(
         {products.map(product => (
           <div
             key={product.id}
-            className="rounded-card border border-dark-200 bg-white px-5 py-4 shadow-card transition-colors hover:border-dark-400 hover:shadow-card-hover motion-reduce:transition-none"
+            className="rounded-card border border-dark-150 bg-white p-5 shadow-card transition-all hover:border-dark-200 hover:shadow-card-hover motion-reduce:transition-none"
           >
-            <div className="flex w-full flex-col gap-3">
-              <div className="flex flex-row justify-between items-center">
-                <Link href={`/products/${product.slug}?from=related`} className="flex-1 min-w-0">
+            <div className="flex w-full flex-col gap-4">
+              <div className="flex flex-row items-start justify-between gap-4">
+                <Link href={`/products/${product.slug}?from=related`} className="min-w-0 flex-1">
                   <ProductItem
                     name={product.name}
                     summary={product.summary}
-                    logoSize={'small'}
+                    logoSize="small"
                     logoUrl={product.logoUrl}
-                    tagVariant={'circle'}
+                    tagVariant="circle"
                     tags={product.tags.map(tag => tag.name)}
                   />
                 </Link>
-                <div className="flex-shrink-0 ml-2">
+                <div className="shrink-0 pt-1">
                   <CompareButton slug={product.slug} source="related" />
                 </div>
               </div>
-              <div className="my-[2px] h-px w-full bg-dark-100" />
-              <div className="flex flex-col gap-6">
-                {product.features && product.features.length > 0 && (
-                  <>
-                    <div className="flex flex-col gap-3">
-                      <div className="flex w-fit flex-col gap-1">
-                        <p className="text-base font-bold tracking-tight text-dark-500">{t('list.feature.title')}</p>
-                        <div className="h-[2px] bg-dark-400" />
-                      </div>
-                      <ProductFeatureGridList
-                        features={product.features.map(item => ({
-                          ...item,
-                          summary: item.summary ?? undefined,
-                        }))}
-                      />
-                    </div>
-                  </>
-                )}
-              </div>
+              {product.features && product.features.length > 0 && (
+                <>
+                  <div className="h-px w-full bg-dark-100" />
+                  <div className="flex flex-col gap-3">
+                    <p className="text-sm font-semibold text-dark-900">{t('list.feature.title')}</p>
+                    <ProductFeatureGridList
+                      features={product.features.map(item => ({
+                        ...item,
+                        summary: item.summary ?? undefined,
+                      }))}
+                    />
+                  </div>
+                </>
+              )}
             </div>
           </div>
         ))}
+        <div className="flex justify-center pt-1">
+          <Link
+            href="/categories"
+            className="inline-flex items-center justify-center rounded-md border border-dark-200 bg-white px-4 py-2 text-sm font-medium text-dark-700 transition-colors hover:bg-surface-100"
+          >
+            {t('empty.button')}
+          </Link>
+        </div>
       </div>
     );
   }

--- a/libs/products/shell/src/components/ProductCard/ProductCard.tsx
+++ b/libs/products/shell/src/components/ProductCard/ProductCard.tsx
@@ -34,15 +34,15 @@ export const ProductCard = ({ product, rank, href, source, layoutId, onClick }: 
       {...(layoutId ? { 'data-layout-id': layoutId } : {})}
       {...{ 'data-source': source }}
     >
-      <div className="flex h-full flex-col gap-4 rounded-card border border-dark-200 bg-white p-5 shadow-card transition-all duration-200 ease-out group-hover:-translate-y-0.5 group-hover:border-dark-400 group-hover:shadow-card-hover group-focus-visible:-translate-y-0.5 group-focus-visible:border-dark-400 group-focus-visible:shadow-card-hover group-focus-visible:ring-2 group-focus-visible:ring-dark-900/70 group-focus-visible:ring-offset-2 group-focus-visible:ring-offset-white active:translate-y-0 motion-reduce:transform-none motion-reduce:transition-none">
+      <div className="flex h-full flex-col gap-4 rounded-card border border-dark-150 bg-white p-4 shadow-card transition-all duration-200 ease-out group-hover:-translate-y-0.5 group-hover:border-dark-200 group-hover:shadow-card-hover group-focus-visible:-translate-y-0.5 group-focus-visible:border-dark-200 group-focus-visible:shadow-card-hover group-focus-visible:ring-2 group-focus-visible:ring-dark-900/70 group-focus-visible:ring-offset-2 group-focus-visible:ring-offset-white active:translate-y-0 motion-reduce:transform-none motion-reduce:transition-none md:gap-5 md:p-5">
         {rank !== undefined && (
-          <div className="flex items-center gap-2.5">
-            <span className="text-xs font-bold leading-none tabular-nums text-dark-500 transition-colors duration-200 ease-out group-hover:text-dark-900 group-focus-visible:text-dark-900 motion-reduce:transition-none">
+          <div className="flex items-center gap-3">
+            <span className="flex h-6 w-6 items-center justify-center rounded-md bg-dark-900 text-2xs font-bold tabular-nums text-white transition-colors duration-200 ease-out group-hover:bg-dark-700 motion-reduce:transition-none">
               {rank}
             </span>
             <span
               aria-hidden="true"
-              className="h-px flex-1 bg-dark-200 transition-colors duration-200 ease-out group-hover:bg-dark-400 group-focus-visible:bg-dark-400 motion-reduce:transition-none"
+              className="h-px flex-1 bg-dark-100 transition-colors duration-200 ease-out group-hover:bg-dark-150 group-focus-visible:bg-dark-150 motion-reduce:transition-none"
             />
           </div>
         )}
@@ -57,6 +57,7 @@ export const ProductCard = ({ product, rank, href, source, layoutId, onClick }: 
             logoSize="small"
             summary={product.summary ?? undefined}
             tags={product.tags.map(tag => tag.name)}
+            tagVariant="circle"
             maxTagItems={1}
             isStacked
           />

--- a/libs/products/shell/src/components/ProductCompany/ProductCompany.tsx
+++ b/libs/products/shell/src/components/ProductCompany/ProductCompany.tsx
@@ -33,18 +33,18 @@ function formatStartAt(startAt: unknown) {
 export const ProductCompany = bind(useProductCompany, ({ company }: ProductCompanyViewProps) => {
   const t = useTranslations('ProductDetail');
 
-  const labelClassName = 'w-[70px] shrink-0 font-bold tracking-[-0.024em] text-dark-700';
-  const valueClassName = 'text-dark-600';
+  const labelClassName = 'w-[72px] shrink-0 text-sm font-medium text-dark-500';
+  const valueClassName = 'text-sm text-dark-800';
 
   return (
     <div>
-      <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
         <div className="flex flex-col gap-3">
-          <div className="flex w-fit flex-col gap-1">
-            <p className="text-base font-bold tracking-tight text-dark-500">{t('company.basicInfo')}</p>
+          <div className="mb-1 flex w-fit flex-col gap-1">
+            <p className="text-sm font-semibold text-dark-900">{t('company.basicInfo')}</p>
             <div className="h-[2px] bg-dark-400" />
           </div>
-          <div className="flex flex-col gap-1.5">
+          <div className="flex flex-col gap-2">
             {company?.name && (
               <div className="flex">
                 <p className={labelClassName}>{t('company.field.name')}</p>

--- a/libs/products/shell/src/components/ProductDescription/ProductDescription.tsx
+++ b/libs/products/shell/src/components/ProductDescription/ProductDescription.tsx
@@ -13,7 +13,7 @@ export const ProductDescription = bind(useProductDescription, ({ description }) 
   const sanitizedDescription = DOMPurify.sanitize(description);
 
   return (
-    <div className="text-sm font-normal leading-relaxed text-dark-700 [&_blockquote]:my-6 [&_blockquote]:border-l-4 [&_blockquote]:border-dark-900 [&_blockquote]:bg-dark-100 [&_blockquote]:px-4 [&_blockquote]:py-3 [&_blockquote]:text-dark-900 [&_blockquote]:not-italic [&_br]:block [&_br]:content-[''] [&_br]:mb-1 [&_hr]:my-6 [&_hr]:border-0 [&_hr]:border-t [&_hr]:border-solid [&_hr]:border-dark-100 [&_p]:my-1 [&_p.blank]:hidden">
+    <div className="prose prose-sm max-w-none text-dark-700 [&_blockquote]:my-6 [&_blockquote]:rounded-r-card [&_blockquote]:border-l-4 [&_blockquote]:border-dark-900 [&_blockquote]:bg-surface-100 [&_blockquote]:px-4 [&_blockquote]:py-3 [&_blockquote]:text-dark-900 [&_blockquote]:not-italic [&_br]:block [&_br]:content-[''] [&_br]:mb-1 [&_hr]:my-6 [&_hr]:border-0 [&_hr]:border-t [&_hr]:border-solid [&_hr]:border-dark-150 [&_h3]:mt-6 [&_h3]:text-base [&_h3]:font-semibold [&_h3]:text-dark-900 [&_p]:my-2 [&_p.blank]:hidden [&_ul]:my-3 [&_ul]:list-disc [&_ul]:pl-5">
       <div
         dangerouslySetInnerHTML={{
           __html: sanitizedDescription,

--- a/libs/products/shell/src/components/ProductInformation/ProductInformation.tsx
+++ b/libs/products/shell/src/components/ProductInformation/ProductInformation.tsx
@@ -12,6 +12,7 @@ export const ProductInformation = bind(useProductInformation, ({ name, logoUrl, 
     isSummaryNoWrap={true}
     isAlignCenter
     nameAs="h1"
+    tagVariant="circle"
     tags={tags && tags.map(tag => tag.name)}
   />
 ));

--- a/libs/products/shell/src/components/ProductLinks/ProductLinks.tsx
+++ b/libs/products/shell/src/components/ProductLinks/ProductLinks.tsx
@@ -10,16 +10,12 @@ export const ProductLinks = bind(useProductLinks, ({ links }) => (
   <>
     {links.map((link, index) => (
       <Link key={link.id} href={link.link} target="_blank" rel="noopener noreferrer">
-        <Button variant="shadow" color={index === 0 ? 'primary' : 'secondary'}>
+        <Button variant={index === 0 ? 'shadow' : 'text'} color={index === 0 ? 'primary' : 'secondary'}>
           <div className="flex items-center justify-center gap-2 px-0.5 py-0.5">
-            <Image src={link.iconUrl} alt={link.title} width={24} height={24} />
-            <div className="flex flex-col items-start gap-0.5">
-              <span className={`w-max break-keep text-sm font-medium ${index === 0 ? '' : 'text-dark-900'}`}>
-                {link.title}
-              </span>
-              <span className={`break-keep text-xs font-medium ${index === 0 ? 'text-dark-200' : 'text-dark-400'}`}>
-                {link.displayLink}
-              </span>
+            <Image src={link.iconUrl} alt={link.title} width={20} height={20} className="shrink-0 rounded-sm" />
+            <div className="flex flex-col items-start gap-0">
+              <span className="w-max break-keep text-sm font-semibold text-current">{link.title}</span>
+              {index === 0 && <span className="break-keep text-xs text-dark-400">{link.displayLink}</span>}
             </div>
           </div>
         </Button>

--- a/libs/products/shell/src/components/ProductPhotos/ProductPhotos.tsx
+++ b/libs/products/shell/src/components/ProductPhotos/ProductPhotos.tsx
@@ -17,15 +17,15 @@ export const ProductPhotos = bind(useProductPhotos, ({ photos }: ProductPhotosVi
 
   if (!photos || photos.length === 0) {
     return (
-      <div className="rounded-card border border-dark-200 bg-white px-4 py-4 shadow-card">
+      <div className="rounded-card border border-dark-150 bg-surface-100 px-5 py-6 text-center">
         <p className="text-sm text-dark-500">{t('photo.empty')}</p>
       </div>
     );
   }
   return (
-    <div className="rounded-card border border-dark-200 bg-white px-2 py-2 shadow-card">
+    <div className="rounded-card border border-dark-150 bg-white p-3 shadow-card">
       {photos && (
-        <div className="relative flex w-max gap-2 overflow-auto">
+        <div className="relative flex w-max gap-3 overflow-auto">
           {photos.map(photo => (
             <Zoom key={photo.imageUrl}>
               <Image
@@ -33,7 +33,7 @@ export const ProductPhotos = bind(useProductPhotos, ({ photos }: ProductPhotosVi
                 alt={photo.imageAlt}
                 sizes="350px"
                 fill={true}
-                className="!relative !h-[220px] !w-auto rounded-lg border border-dark-200 object-contain"
+                className="!relative !h-[220px] !w-auto rounded-lg border border-dark-150 object-contain"
               />
             </Zoom>
           ))}

--- a/libs/products/shell/src/components/ProductTableOfContent/ProductTableOfContent.tsx
+++ b/libs/products/shell/src/components/ProductTableOfContent/ProductTableOfContent.tsx
@@ -6,11 +6,12 @@ import { bind } from '@darun/utils-structure-react';
 import { useProductTableOfContent } from './useProductTableOfContent';
 
 export const ProductTableOfContent = bind(useProductTableOfContent, ({ headings, activeHeadingId }) => (
-  <div className="flex gap-0.5 overflow-x-auto py-2 md:gap-1">
+  <div className="flex gap-1 overflow-x-auto py-2.5 md:gap-2">
     {headings.map(({ id, text }) => (
       <Button
         key={id}
         kind={activeHeadingId === id ? 'textActive' : 'text'}
+        size="sm"
         onClick={() => {
           const target = document.getElementById(id);
 
@@ -18,7 +19,7 @@ export const ProductTableOfContent = bind(useProductTableOfContent, ({ headings,
             return;
           }
 
-          const location = target.getBoundingClientRect().top + window.scrollY - 40;
+          const location = target.getBoundingClientRect().top + window.scrollY - 48;
           window.scrollTo({ top: Math.max(location, 0), behavior: 'smooth' });
         }}
       >

--- a/libs/products/shell/src/components/ProductUserAction/ProductUserAction.tsx
+++ b/libs/products/shell/src/components/ProductUserAction/ProductUserAction.tsx
@@ -21,22 +21,29 @@ export const ProductUserAction = bind(
     }, [error, voted, loading, addToast]);
 
     return (
-      <div className="flex gap-1">
-        <Button variant="shadow" onClick={upvoteProduct} disabled={loading} data-testid="upvote-btn">
-          <div className="flex flex-col items-center justify-center gap-1 px-0.5 py-0.5">
+      <div className="flex items-center gap-2">
+        <Button
+          variant="shadow"
+          color="secondary"
+          size="md"
+          onClick={upvoteProduct}
+          disabled={loading}
+          data-testid="upvote-btn"
+        >
+          <div className="flex items-center justify-center gap-1.5 px-0.5 py-0.5">
             {loading ? (
               <div
                 data-testid="upvote-loading"
-                className="animate-spin rounded-full h-4 w-4 border-b-2 border-gray-900"
+                className="h-4 w-4 animate-spin rounded-full border-2 border-current border-b-transparent"
               />
             ) : error ? (
-              <span data-testid="upvote-error" className="text-red-500 text-xs">
+              <span data-testid="upvote-error" className="text-xs text-red-500">
                 !
               </span>
             ) : (
-              <Heart size={18} color={voted ? '#ec4899' : '#555'} fill={voted ? '#ec4899' : '#555'} />
+              <Heart size={18} className={voted ? 'fill-pink-500 text-pink-500' : 'fill-transparent text-dark-500'} />
             )}
-            <span className="break-keep text-sm font-medium text-dark-700">{voteCount}</span>
+            <span className="break-keep text-sm font-semibold text-dark-700">{voteCount}</span>
           </div>
         </Button>
         <CompareButton slug={slug} source="direct" />

--- a/libs/products/shell/src/components/RankedProductList/RankedProductList.tsx
+++ b/libs/products/shell/src/components/RankedProductList/RankedProductList.tsx
@@ -7,30 +7,42 @@ import { ProductItem } from '../../uis';
 import { useRankedProductList } from './useRankedProductList';
 
 export const RankedProductList = bind(useRankedProductList, ({ products }) => (
-  <div className="grid w-full grid-cols-1 gap-5 md:grid-cols-2">
-    {products.map((product, index) => (
-      <Link
-        key={product.id}
-        href={`/products/${product.slug}?from=trending`}
-        onClick={() =>
-          track(AnalyticsEvents.RANKED_PRODUCT_CLICKED, {
-            productSlug: product.slug,
-            source: 'ranking',
-          })
-        }
-      >
-        <div className="flex items-center gap-3">
-          <p className="min-w-7 text-center text-lg font-bold text-dark-400">{index + 1}</p>
-          <ProductItem
-            name={product.name}
-            logoUrl={product.logoUrl}
-            logoSize={'medium'}
-            summary={product.summary}
-            tags={product.tags.map(tag => tag.name)}
-            maxTagItems={2}
-          />
-        </div>
-      </Link>
-    ))}
+  <div className="grid w-full grid-cols-1 gap-3 md:grid-cols-2 md:gap-4">
+    {products.map((product, index) => {
+      const rank = index + 1;
+      const isTopThree = rank <= 3;
+
+      return (
+        <Link
+          key={product.id}
+          href={`/products/${product.slug}?from=trending`}
+          onClick={() =>
+            track(AnalyticsEvents.RANKED_PRODUCT_CLICKED, {
+              productSlug: product.slug,
+              source: 'ranking',
+            })
+          }
+          className="group block rounded-card border border-transparent p-3 transition-all hover:border-dark-150 hover:bg-white hover:shadow-card motion-reduce:transition-none"
+        >
+          <div className="flex items-center gap-3">
+            <span
+              className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-sm font-bold tabular-nums ${
+                isTopThree ? 'bg-dark-900 text-white' : 'bg-surface-100 text-dark-500'
+              }`}
+            >
+              {rank}
+            </span>
+            <ProductItem
+              name={product.name}
+              logoUrl={product.logoUrl}
+              logoSize="small"
+              summary={product.summary}
+              tags={product.tags.map(tag => tag.name)}
+              maxTagItems={1}
+            />
+          </div>
+        </Link>
+      );
+    })}
   </div>
 ));

--- a/libs/products/shell/src/components/RecentProductList/RecentProductList.tsx
+++ b/libs/products/shell/src/components/RecentProductList/RecentProductList.tsx
@@ -5,7 +5,7 @@ import { ProductCard } from '../ProductCard';
 import { useRecentProductList } from './useRecentProductList';
 
 export const RecentProductList = bind(useRecentProductList, ({ products, locale }) => (
-  <div className="grid grid-cols-2 gap-3 md:grid-cols-3 md:gap-4 lg:grid-cols-4">
+  <div className="grid grid-cols-2 gap-3 md:grid-cols-3 md:gap-4 lg:grid-cols-4 xl:gap-5">
     {products.map(product => (
       <ProductCard
         key={product.id}

--- a/libs/products/shell/src/shells/AlternativeProductSection/AlternativeProductSection.tsx
+++ b/libs/products/shell/src/shells/AlternativeProductSection/AlternativeProductSection.tsx
@@ -16,13 +16,16 @@ export const AlternativeProductSection = ({ slug }: AlternativeProductSectionPro
 
   if (alternatives.length === 0) {
     return (
-      <section className="flex flex-col gap-5 py-4 md:py-6">
+      <section className="flex flex-col gap-4 py-4 md:gap-5 md:py-6">
         <SectionHeader title={t('more.title')} subtitle={t('more.description')} />
-        <div data-testid="alt-empty" className="flex flex-col items-center justify-center py-12 text-center">
-          <p className="text-sm text-dark-500 mb-4">{t('empty.title')}</p>
+        <div
+          data-testid="alt-empty"
+          className="flex flex-col items-center justify-center rounded-card border border-dark-150 bg-surface-100 px-4 py-12 text-center"
+        >
+          <p className="mb-4 text-sm text-dark-500">{t('empty.title')}</p>
           <Link
             href="/categories"
-            className="inline-flex items-center justify-center px-4 py-2 text-sm bg-surface-100 text-dark-700 rounded-md border border-dark-300 hover:bg-surface-200 transition-colors font-medium"
+            className="inline-flex items-center justify-center rounded-md border border-dark-300 bg-white px-4 py-2 text-sm font-medium text-dark-700 transition-colors hover:bg-surface-200"
           >
             {t('empty.button')}
           </Link>
@@ -32,11 +35,9 @@ export const AlternativeProductSection = ({ slug }: AlternativeProductSectionPro
   }
 
   return (
-    <section className="flex flex-col gap-5 py-4 md:py-6">
+    <section className="flex flex-col gap-4 py-4 md:gap-5 md:py-6">
       <SectionHeader title={t('more.title')} subtitle={t('more.description')} />
-      <div>
-        <ProductAlternativeList slug={slug} />
-      </div>
+      <ProductAlternativeList slug={slug} />
     </section>
   );
 };

--- a/libs/products/shell/src/shells/CategoryNavigationSection/CategoryNavigationSection.tsx
+++ b/libs/products/shell/src/shells/CategoryNavigationSection/CategoryNavigationSection.tsx
@@ -45,7 +45,7 @@ export const CategoryNavigationSection = () => {
           }
         />
         {categories.length > 0 ? (
-          <div className="grid grid-cols-2 gap-3 md:grid-cols-3 md:gap-4 lg:grid-cols-4">
+          <div className="flex flex-wrap gap-2 md:gap-3">
             {categories.map(category => (
               <Link
                 key={category.id}
@@ -56,14 +56,14 @@ export const CategoryNavigationSection = () => {
                     source: 'home-bar',
                   })
                 }
-                className="flex min-h-20 items-center justify-center rounded-card border border-dark-200 bg-white px-4 py-3 text-center text-sm font-semibold tracking-tight text-dark-900 transition-colors duration-200 ease-out hover:border-dark-400 hover:text-dark-900 focus-visible:border-dark-400 focus-visible:text-dark-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-dark-900/70 motion-reduce:transition-none sm:text-base"
+                className="inline-flex items-center rounded-full border border-dark-150 bg-white px-4 py-2 text-sm font-medium text-dark-700 transition-colors hover:border-dark-300 hover:bg-surface-100 hover:text-dark-900 focus-visible:border-dark-300 focus-visible:bg-surface-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-dark-900/70 motion-reduce:transition-none sm:px-5 sm:py-2.5"
               >
                 {locale === 'ko' ? category.labelKo : category.labelEn}
               </Link>
             ))}
           </div>
         ) : (
-          <div className="flex min-h-40 items-center justify-center rounded-card-lg border border-dark-200 bg-surface-100 px-6 py-10 text-center text-sm font-medium text-dark-600 sm:text-base">
+          <div className="flex min-h-40 items-center justify-center rounded-card-lg border border-dark-150 bg-surface-100 px-6 py-10 text-center text-sm font-medium text-dark-600 sm:text-base">
             {t('home.category.empty')}
           </div>
         )}

--- a/libs/products/shell/src/shells/CategoryProductSection/CategoryProductSection.tsx
+++ b/libs/products/shell/src/shells/CategoryProductSection/CategoryProductSection.tsx
@@ -20,6 +20,12 @@ const PRODUCTS_BY_CATEGORY_QUERY = gql`
         name
       }
     }
+    categories(first: 100, locale: $locale) {
+      id
+      slug
+      labelKo
+      labelEn
+    }
   }
 `;
 
@@ -36,13 +42,21 @@ type Product = {
   }>;
 };
 
+type Category = {
+  id: string;
+  slug: string;
+  labelKo: string;
+  labelEn: string;
+};
+
 type ProductsByCategoryQueryData = {
   productsByCategory?: Product[] | null;
+  categories?: Category[] | null;
 };
 
 export function CategoryProductSection({ slug }: { slug: string }) {
   const locale = useLocale();
-  const t = useTranslations('Category');
+  const t = useTranslations('category');
   const { data } = useSuspenseQuery<ProductsByCategoryQueryData>(PRODUCTS_BY_CATEGORY_QUERY, {
     variables: {
       slug,
@@ -51,7 +65,8 @@ export function CategoryProductSection({ slug }: { slug: string }) {
   });
 
   const products = data?.productsByCategory ?? [];
-  const categoryLabel = t('title', { category: slug });
+  const category = data?.categories?.find(c => c.slug === slug);
+  const categoryLabel = category ? (locale === 'ko' ? category.labelKo : category.labelEn) : slug;
   const emptyLabel = t('empty');
 
   return (
@@ -63,7 +78,7 @@ export function CategoryProductSection({ slug }: { slug: string }) {
             {emptyLabel}
           </div>
         ) : (
-          <div className="grid grid-cols-1 gap-3 md:grid-cols-2 md:gap-4 lg:grid-cols-3">
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 md:gap-4 lg:grid-cols-3 xl:gap-5">
             {products.map(product => (
               <ProductCard
                 key={product.id}

--- a/libs/products/shell/src/shells/ProductDescriptionSection/ProductDescriptionSection.tsx
+++ b/libs/products/shell/src/shells/ProductDescriptionSection/ProductDescriptionSection.tsx
@@ -12,9 +12,9 @@ export const ProductDescriptionSection = ({ slug }: ProductDescriptionSectionPro
   const t = useTranslations('ProductDetail');
 
   return (
-    <section className="flex flex-col gap-5 py-4 md:py-6" id="description">
+    <section className="flex flex-col gap-4 py-4 md:gap-5 md:py-6" id="description">
       <SectionHeader title={t('description.title')} />
-      <div className="[&_div]:text-dark-700">
+      <div className="rounded-card border border-dark-150 bg-white p-5 shadow-card">
         <ProductDescription slug={slug} />
       </div>
     </section>

--- a/libs/products/shell/src/shells/ProductDetailCompanySection/ProductDetailCompanySection.tsx
+++ b/libs/products/shell/src/shells/ProductDetailCompanySection/ProductDetailCompanySection.tsx
@@ -10,9 +10,9 @@ export const ProductDetailCompanySection = ({ slug }: ProductDetailCompanySectio
   const t = useTranslations('ProductDetail');
 
   return (
-    <section className="flex flex-col gap-5 py-4 md:py-6" id="company-info">
+    <section className="flex flex-col gap-4 py-4 md:gap-5 md:py-6" id="company-info">
       <SectionHeader title={t('company.title')} subtitle={t('company.description')} />
-      <div className="[&_p.text-dark-500]:!text-sm [&_p.text-dark-500]:!text-dark-600 [&_div.bg-dark-400]:!bg-dark-300 [&_div.bg-dark-400]:!h-px [&_p.text-dark-700]:!w-16 [&_p.text-dark-700]:!text-dark-500 [&_p.text-dark-700]:!font-normal [&_p.text-dark-700]:!text-sm [&_p.text-dark-600]:!text-dark-600 [&_p.text-dark-600]:!text-sm">
+      <div className="rounded-card border border-dark-150 bg-white p-5 shadow-card">
         <ProductCompany slug={slug} />
       </div>
     </section>

--- a/libs/products/shell/src/shells/ProductDetailFeatureSection/ProductDetailFeatureSection.tsx
+++ b/libs/products/shell/src/shells/ProductDetailFeatureSection/ProductDetailFeatureSection.tsx
@@ -12,11 +12,9 @@ export const ProductDetailFeatureSection = ({ slug }: ProductDetailFeatureSectio
   const t = useTranslations('ProductDetail');
 
   return (
-    <section className="flex flex-col gap-5 py-4 md:py-6" id="features">
+    <section className="flex flex-col gap-4 py-4 md:gap-5 md:py-6" id="features">
       <SectionHeader title={t('feature.title')} />
-      <div className="[&_img]:!rounded-md">
-        <ProductFeatureList slug={slug} />
-      </div>
+      <ProductFeatureList slug={slug} />
     </section>
   );
 };

--- a/libs/products/shell/src/shells/ProductPhotoSection/ProductPhotoSection.tsx
+++ b/libs/products/shell/src/shells/ProductPhotoSection/ProductPhotoSection.tsx
@@ -10,11 +10,9 @@ export const ProductPhotoSection = ({ slug }: ProductPhotoSectionProps) => {
   const t = useTranslations('ProductDetail');
 
   return (
-    <section className="flex flex-col gap-5 py-4 md:py-6" id="screenshot">
+    <section className="flex flex-col gap-4 py-4 md:gap-5 md:py-6" id="screenshot">
       <SectionHeader title={t('photo.title')} />
-      <div className="[&_img]:!rounded-md">
-        <ProductPhotos slug={slug} />
-      </div>
+      <ProductPhotos slug={slug} />
     </section>
   );
 };

--- a/libs/products/shell/src/shells/ProductSummary/ProductSummary.tsx
+++ b/libs/products/shell/src/shells/ProductSummary/ProductSummary.tsx
@@ -3,10 +3,12 @@ import { ProductInformation, ProductUserAction } from '../../components';
 type ProductSummaryProps = { slug: string };
 
 export const ProductSummary = ({ slug }: ProductSummaryProps) => (
-  <div className="py-4 flex justify-between items-center">
-    <div style={{ viewTransitionName: `product-${slug}` }}>
+  <div className="flex flex-col gap-4 py-4 md:flex-row md:items-start md:justify-between md:gap-6">
+    <div className="min-w-0 flex-1" style={{ viewTransitionName: `product-${slug}` }}>
       <ProductInformation slug={slug} />
     </div>
-    <ProductUserAction slug={slug} />
+    <div className="shrink-0">
+      <ProductUserAction slug={slug} />
+    </div>
   </div>
 );

--- a/libs/products/shell/src/shells/ProductSummaryLink/ProductSummaryLink.tsx
+++ b/libs/products/shell/src/shells/ProductSummaryLink/ProductSummaryLink.tsx
@@ -3,7 +3,7 @@ import { ProductLinks } from '../../components';
 type ProductSummaryLinkProps = { slug: string };
 
 export const ProductSummaryLink = ({ slug }: ProductSummaryLinkProps) => (
-  <div className="flex gap-3 pb-3 overflow-x-auto">
+  <div className="flex gap-2 pb-2 pt-1 overflow-x-auto">
     <ProductLinks slug={slug} />
   </div>
 );

--- a/libs/products/shell/src/shells/ProductTocSection/ProductTocSection.test.tsx
+++ b/libs/products/shell/src/shells/ProductTocSection/ProductTocSection.test.tsx
@@ -34,7 +34,7 @@ describe('ProductTocSection', () => {
       root?.render(<ProductTocSection.ViewComponent isFixed={true} />);
     });
     expect(container.querySelector('[data-testid="mock-toc"]')).not.toBeNull();
-    expect(container.innerHTML).toContain('h-10');
+    expect(container.innerHTML).toContain('h-12');
   });
 
   it('renders relative section without offset spacer', () => {
@@ -42,6 +42,6 @@ describe('ProductTocSection', () => {
       root?.render(<ProductTocSection.ViewComponent isFixed={false} />);
     });
     expect(container.querySelector('[data-testid="mock-toc"]')).not.toBeNull();
-    expect(container.innerHTML).not.toContain('h-10');
+    expect(container.innerHTML).not.toContain('h-12');
   });
 });

--- a/libs/products/shell/src/shells/ProductTocSection/ProductTocSection.tsx
+++ b/libs/products/shell/src/shells/ProductTocSection/ProductTocSection.tsx
@@ -7,9 +7,9 @@ import { useProductTocSection } from './useProductTocSection';
 
 export const ProductTocSection = bind(useProductTocSection, ({ isFixed }) => (
   <>
-    {isFixed && <div className="h-10" />}
+    {isFixed && <div className="h-12" />}
     <div
-      className={`${isFixed ? 'fixed shadow-card' : 'relative'} w-full z-[100] bg-dark-000 border-y border-dark-100 top-0`}
+      className={`${isFixed ? 'fixed shadow-card' : 'relative'} w-full z-[100] bg-white/95 backdrop-blur-sm border-b border-dark-150 top-0`}
     >
       <ContentArea>
         <ProductTableOfContent />

--- a/libs/products/shell/src/shells/RelatedProductsSection/RelatedProductsSection.tsx
+++ b/libs/products/shell/src/shells/RelatedProductsSection/RelatedProductsSection.tsx
@@ -63,9 +63,9 @@ export const RelatedProductsSection = ({ slug }: { slug: string }) => {
   };
 
   return (
-    <div data-testid="related-products-section" className="py-4">
+    <div data-testid="related-products-section">
       <SectionHeader title={t('related.title')} />
-      <div className="mt-4 grid grid-cols-2 gap-3 md:grid-cols-3 md:gap-4 lg:grid-cols-4">
+      <div className="mt-3 grid grid-cols-2 gap-3 md:mt-4 md:grid-cols-3 md:gap-4 lg:grid-cols-4 xl:gap-5">
         {alternatives.slice(0, 4).map((alt, index) => (
           <ProductCard
             key={alt.id}

--- a/libs/products/shell/src/shells/TrendingProductSection/TrendingProductSection.tsx
+++ b/libs/products/shell/src/shells/TrendingProductSection/TrendingProductSection.tsx
@@ -98,7 +98,7 @@ const TrendingProductsView = ({
             {emptyLabel}
           </div>
         ) : (
-          <div className="grid grid-cols-2 gap-3 md:grid-cols-3 md:gap-4 lg:grid-cols-4">
+          <div className="grid grid-cols-2 gap-3 md:grid-cols-3 md:gap-4 lg:grid-cols-4 xl:gap-5">
             {products.map((product, index) => (
               <ProductCard
                 key={product.id}

--- a/libs/products/shell/src/uis/FeatureItem/FeatureItem.tsx
+++ b/libs/products/shell/src/uis/FeatureItem/FeatureItem.tsx
@@ -12,19 +12,19 @@ type FeatureItemProps = {
 };
 
 export const FeatureItem = ({ emoji, name, description, screenshots }: FeatureItemProps) => (
-  <div className="rounded-card border border-dark-200 bg-white px-4 py-3 shadow-card transition-colors hover:border-dark-400 hover:shadow-card-hover motion-reduce:transition-none">
+  <div className="rounded-card border border-dark-150 bg-white p-5 shadow-card transition-all hover:border-dark-200 hover:shadow-card-hover motion-reduce:transition-none">
     <div className="flex w-full flex-col gap-4">
-      <div className="flex items-center gap-3">
-        <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-lg border border-dark-200 bg-surface-100">
-          <span className="text-2xl">{emoji ?? '💎'}</span>
+      <div className="flex items-start gap-3">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-dark-150 bg-surface-100">
+          <span className="text-xl">{emoji ?? '💎'}</span>
         </div>
         <div className="flex flex-col">
-          <p className="text-lg font-bold tracking-tight text-dark-900">{name}</p>
-          {description && <p className="text-sm font-normal text-dark-600">{description}</p>}
+          <p className="text-base font-semibold tracking-tight text-dark-900">{name}</p>
+          {description && <p className="text-sm leading-relaxed text-dark-500">{description}</p>}
         </div>
       </div>
       {screenshots && screenshots.length > 0 && (
-        <div className="flex w-full gap-2 overflow-auto">
+        <div className="flex w-full gap-3 overflow-auto rounded-lg bg-surface-100 p-2">
           {screenshots.map(screenshot => (
             <Image
               key={screenshot.id}
@@ -33,7 +33,7 @@ export const FeatureItem = ({ emoji, name, description, screenshots }: FeatureIt
               sizes="800px"
               width={800}
               height={220}
-              className="h-[220px] w-auto rounded-lg border border-dark-200 object-contain"
+              className="h-[220px] w-auto rounded-lg border border-dark-150 object-contain"
             />
           ))}
         </div>

--- a/libs/products/shell/src/uis/ProductItem/ProductItem.tsx
+++ b/libs/products/shell/src/uis/ProductItem/ProductItem.tsx
@@ -52,7 +52,7 @@ export const ProductItem = ({
     <Component
       className={
         isStacked
-          ? 'flex w-full flex-col gap-3 overflow-visible'
+          ? 'flex w-full flex-col gap-3.5 overflow-visible md:gap-4'
           : `flex w-full gap-3 overflow-visible ${isAlignCenter ? 'items-center' : 'items-start'}`
       }
     >
@@ -62,31 +62,31 @@ export const ProductItem = ({
         alt={t('productItem.logoAlt', { name })}
         width={logoSizes[logoSize].imageSize}
         height={logoSizes[logoSize].imageSize}
-        className={`object-contain ${logoSize === 'small' ? 'rounded-xl' : 'rounded-2xl'}`}
+        className={`shrink-0 object-contain ${logoSize === 'small' ? 'rounded-xl' : 'rounded-2xl'}`}
       />
-      <div className="flex min-w-0 flex-col gap-1 overflow-hidden">
-        <div className="flex flex-col gap-1">
+      <div className="flex min-w-0 flex-col gap-2 overflow-hidden">
+        <div className="flex flex-col gap-0.5">
           <NameTag
-            className={`m-0 text-lg font-bold tracking-tight text-dark-900 md:text-xl ${isStacked ? 'line-clamp-2' : ''}`}
+            className={`m-0 text-base font-semibold tracking-tight text-dark-900 ${isStacked ? 'line-clamp-2' : 'md:text-lg'}`}
           >
             {name}
           </NameTag>
           {summary &&
             (isStacked ? (
-              <p className="line-clamp-2 text-xs leading-snug text-dark-500 md:text-sm">{summary}</p>
+              <p className="line-clamp-2 text-sm leading-snug text-dark-500">{summary}</p>
             ) : isSummaryNoWrap ? (
-              <p className="w-full overflow-hidden text-ellipsis whitespace-nowrap text-xs leading-snug text-dark-500 md:text-sm">
+              <p className="w-full overflow-hidden text-ellipsis whitespace-nowrap text-sm leading-snug text-dark-500">
                 {summary}
               </p>
             ) : (
-              <p className="text-xs leading-snug text-dark-500 md:text-sm">{summary}</p>
+              <p className="text-sm leading-snug text-dark-500">{summary}</p>
             ))}
         </div>
         {(tags || specialTags) && (
-          <div className={`flex items-center gap-1 overflow-x-auto ${isStacked ? '' : 'mr-3'}`}>
+          <div className={`flex items-center gap-1.5 overflow-x-auto ${isStacked ? '' : 'mr-3'}`}>
             {tags &&
               (maxTagItems && tags.length > maxTagItems ? (
-                <div className="flex items-center gap-1">
+                <div className="flex items-center gap-2">
                   {tags.slice(0, maxTagItems).map(tag => (
                     <Chip
                       key={`tag-${tag}`}
@@ -96,7 +96,7 @@ export const ProductItem = ({
                       {tag}
                     </Chip>
                   ))}
-                  <span className="text-xs text-dark-500">+{tags.length - maxTagItems}</span>
+                  <span className="text-xs font-medium text-dark-400">+{tags.length - maxTagItems}</span>
                 </div>
               ) : (
                 tags.map(tag => (
@@ -111,7 +111,7 @@ export const ProductItem = ({
               ))}
             {specialTags && (
               <>
-                <span className="text-dark-500">•</span>
+                <span className="text-dark-400">•</span>
                 {specialTags.map(tag => (
                   <Chip key={`special-tag-${tag}`} variant={tagVariant} color="filledDark">
                     {tag}

--- a/libs/search/datasource/src/entities/SearchableProductSchema.ts
+++ b/libs/search/datasource/src/entities/SearchableProductSchema.ts
@@ -11,34 +11,34 @@ import { ObjectId } from 'mongoose';
 export class SearchableProductSchema {
   public _id: ObjectId;
 
-  @prop()
+  @prop({ type: () => String })
   public productId: string;
 
-  @prop()
+  @prop({ type: () => String })
   public name: string;
 
-  @prop()
+  @prop({ type: () => String })
   public slug: string;
 
-  @prop()
+  @prop({ type: () => String })
   public summary: string;
 
-  @prop()
+  @prop({ type: () => String })
   public description?: string;
 
   @prop({ type: () => [String], default: [] })
   public tags: string[];
 
-  @prop({ default: '' })
+  @prop({ type: () => String, default: '' })
   public category: string;
 
-  @prop({ default: 0 })
+  @prop({ type: () => Number, default: 0 })
   public votes: number;
 
-  @prop()
+  @prop({ type: () => Date })
   public createdAt?: Date;
 
-  @prop()
+  @prop({ type: () => Date })
   public publishedAt?: Date;
 }
 

--- a/libs/search/shell/src/shells/SearchEmptyState/CategoryShortcutGrid/CategoryShortcutGrid.tsx
+++ b/libs/search/shell/src/shells/SearchEmptyState/CategoryShortcutGrid/CategoryShortcutGrid.tsx
@@ -33,7 +33,7 @@ export const CategoryShortcutGrid = () => {
   return (
     <div
       data-testid="category-shortcut-grid"
-      className="grid grid-cols-2 gap-2 sm:grid-cols-4"
+      className="grid grid-cols-2 gap-2 sm:grid-cols-4 md:gap-3"
       role="list"
       aria-label="Browse by category"
     >
@@ -43,7 +43,7 @@ export const CategoryShortcutGrid = () => {
           type="button"
           role="listitem"
           onClick={() => handleClick(cat.slug)}
-          className="rounded-xl bg-surface-100 px-4 py-3 text-sm font-medium text-dark-700 transition-colors hover:bg-dark-100 hover:text-dark-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-dark-900/70 focus-visible:ring-offset-2"
+          className="rounded-xl border border-dark-150 bg-white px-4 py-3 text-sm font-medium text-dark-700 transition-colors hover:border-dark-300 hover:bg-surface-100 hover:text-dark-900 focus-visible:border-dark-300 focus-visible:bg-surface-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-dark-900/70"
         >
           {locale === 'ko' ? cat.labelKo : cat.labelEn}
         </button>

--- a/libs/search/shell/src/shells/SearchEmptyState/PopularQueriesStripe/PopularQueriesStripe.tsx
+++ b/libs/search/shell/src/shells/SearchEmptyState/PopularQueriesStripe/PopularQueriesStripe.tsx
@@ -43,7 +43,7 @@ export const PopularQueriesStripe = () => {
   return (
     <div
       data-testid="popular-queries-stripe"
-      className="flex gap-2 overflow-x-auto py-3 scrollbar-hide"
+      className="flex gap-2 overflow-x-auto scrollbar-hide"
       role="list"
       aria-label="Popular searches"
     >
@@ -53,7 +53,7 @@ export const PopularQueriesStripe = () => {
           type="button"
           role="listitem"
           onClick={() => handleClick(query)}
-          className="rounded-full bg-surface-100 px-3 py-1.5 text-sm font-medium text-dark-700 transition-colors whitespace-nowrap hover:bg-dark-100 hover:text-dark-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-dark-900/70 focus-visible:ring-offset-2 motion-reduce:transition-none"
+          className="inline-flex items-center rounded-full border border-dark-150 bg-white px-4 py-2 text-sm font-medium text-dark-700 transition-colors hover:border-dark-300 hover:bg-surface-100 hover:text-dark-900 focus-visible:border-dark-300 focus-visible:bg-surface-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-dark-900/70 motion-reduce:transition-none"
         >
           {query}
         </button>

--- a/libs/search/shell/src/shells/SearchEmptyState/TrendingProductPreview/TrendingProductPreview.tsx
+++ b/libs/search/shell/src/shells/SearchEmptyState/TrendingProductPreview/TrendingProductPreview.tsx
@@ -3,8 +3,8 @@
 import { gql } from '@apollo/client';
 import { useSuspenseQuery } from '@apollo/client/react';
 import { AnalyticsEvents, track } from '@darun/analytics-client';
-import { TrendingPreviewDocument } from '@darun/provider-graphql';
 import { ProductCard } from '@darun/products-shell';
+import { TrendingPreviewDocument } from '@darun/provider-graphql';
 import { useLocale } from 'next-intl';
 
 const TRENDING_PREVIEW_QUERY = gql`
@@ -34,7 +34,7 @@ export const TrendingProductPreview = () => {
 
   return (
     <div data-testid="trending-preview">
-      <div className="grid grid-cols-2 gap-3 md:grid-cols-3 md:gap-4 lg:grid-cols-4">
+      <div className="grid grid-cols-2 gap-3 md:grid-cols-3 md:gap-4 lg:grid-cols-4 xl:gap-5">
         {products.slice(0, 6).map((product, index) => (
           <ProductCard
             key={product.id}

--- a/libs/shared/ui/src/components/Chip.test.tsx
+++ b/libs/shared/ui/src/components/Chip.test.tsx
@@ -29,6 +29,6 @@ describe('Chip', () => {
   it('applies color variant classes', () => {
     const { container } = render(<Chip color="filledDark">어두운 칩</Chip>);
 
-    expect(container.firstChild).toHaveClass('border-dark-900', 'bg-dark-900', 'text-dark-100');
+    expect(container.firstChild).toHaveClass('border-transparent', 'bg-dark-900', 'text-dark-100');
   });
 });

--- a/libs/shared/ui/src/components/Chip.tsx
+++ b/libs/shared/ui/src/components/Chip.tsx
@@ -3,14 +3,14 @@ import { AnchorHTMLAttributes, ButtonHTMLAttributes, HTMLAttributes, ReactNode }
 import { cn } from '../lib/utils';
 
 const chipVariants = {
-  square: 'rounded-chip px-1.5 py-1 text-xs',
-  circle: 'rounded-2xl px-2 py-1 text-xs',
+  square: 'rounded-chip px-2 py-1 text-xs',
+  circle: 'rounded-pill px-2.5 py-1 text-xs',
 } as const;
 
 const chipColors = {
-  filledGray: 'border-dark-200 bg-dark-100 text-dark-700',
-  filledDark: 'border-dark-900 bg-dark-900 text-dark-100',
-  outlineGray: 'border-dark-200 bg-transparent text-dark-600',
+  filledGray: 'border-transparent bg-surface-200 text-dark-700',
+  filledDark: 'border-transparent bg-dark-900 text-dark-100',
+  outlineGray: 'border-dark-150 bg-white text-dark-500',
   outlineBrown: 'border-brown-300 bg-transparent text-brown-900',
   outlineLeaf: 'border-leaf-300 bg-transparent text-leaf-900',
   outlineYellow: 'border-yellow-300 bg-transparent text-yellow-900',

--- a/libs/shared/ui/src/components/SectionHeader.tsx
+++ b/libs/shared/ui/src/components/SectionHeader.tsx
@@ -32,11 +32,11 @@ export type SectionHeaderProps = HTMLAttributes<HTMLHeadingElement> & {
 export function SectionHeader({ title, subtitle, moreLink, size, align, className, ...props }: SectionHeaderProps) {
   return (
     <div className={cn(sectionHeaderVariants({ size, align }), className)} {...props}>
-      <div className="flex items-center gap-2">
-        <h2 className="text-xl font-bold text-dark-900 sm:text-2xl">{title}</h2>
-        {moreLink && <span className="ml-auto">{moreLink}</span>}
+      <div className="flex items-baseline gap-3">
+        <h2 className="text-xl font-bold tracking-tight text-dark-900 sm:text-2xl">{title}</h2>
+        {moreLink && <span className="ml-auto shrink-0">{moreLink}</span>}
       </div>
-      {subtitle && <p className="text-sm text-dark-600 sm:text-base">{subtitle}</p>}
+      {subtitle && <p className="text-sm leading-relaxed text-dark-500 sm:text-base">{subtitle}</p>}
     </div>
   );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,57 +6,9 @@ settings:
 
 catalogs:
   default:
-    '@apollo/client':
-      specifier: 4.2.0
-      version: 4.2.0
-    '@apollo/server':
-      specifier: 5.5.1
-      version: 5.5.1
-    '@as-integrations/aws-lambda':
-      specifier: 4.0.1
-      version: 4.0.1
-    '@mantine/core':
-      specifier: 9.5.1
-      version: 9.5.1
-    '@mantine/dropzone':
-      specifier: 9.5.1
-      version: 9.5.1
-    '@mantine/form':
-      specifier: 9.5.1
-      version: 9.5.1
-    '@mantine/hooks':
-      specifier: 9.5.1
-      version: 9.5.1
-    '@mantine/notifications':
-      specifier: 9.5.1
-      version: 9.5.1
-    '@playwright/test':
-      specifier: 1.59.1
-      version: 1.59.1
-    '@sentry/aws-serverless':
-      specifier: 10.38.0
-      version: 10.38.0
-    '@sentry/esbuild-plugin':
-      specifier: 4.9.1
-      version: 4.9.1
-    '@sentry/nextjs':
-      specifier: 10.38.0
-      version: 10.38.0
-    '@sentry/profiling-node':
-      specifier: 10.38.0
-      version: 10.38.0
     '@tailwindcss/postcss':
       specifier: 4.3.3
       version: 4.3.3
-    '@testing-library/jest-dom':
-      specifier: 6.9.1
-      version: 6.9.1
-    '@types/react':
-      specifier: 19.2.14
-      version: 19.2.14
-    '@types/react-dom':
-      specifier: 19.2.4
-      version: 19.2.4
     '@vitest/coverage-v8':
       specifier: 4.1.10
       version: 4.1.10
@@ -72,75 +24,30 @@ catalogs:
     class-variance-authority:
       specifier: 0.7.1
       version: 0.7.1
-    cloudinary:
-      specifier: 2.10.0
-      version: 2.10.0
     clsx:
       specifier: 2.1.1
       version: 2.1.1
-    drizzle-orm:
-      specifier: 0.45.2
-      version: 0.45.2
-    esbuild:
-      specifier: 0.27.3
-      version: 0.27.3
     eslint:
       specifier: 10.8.0
       version: 10.8.0
-    eslint-config-next:
-      specifier: 16.2.12
-      version: 16.2.12
-    firebase:
-      specifier: 10.8.1
-      version: 10.8.1
-    firebase-admin:
-      specifier: 13.6.1
-      version: 13.6.1
-    graphql:
-      specifier: 16.12.0
-      version: 16.12.0
-    graphql-tag-swc-plugin:
-      specifier: 1.1.0
-      version: 1.1.0
     lefthook:
       specifier: 1.12.3
       version: 1.12.3
     lucide-react:
       specifier: 0.468.0
       version: 0.468.0
-    mongoose:
-      specifier: 9.2.1
-      version: 9.2.1
-    next:
-      specifier: 16.2.6
-      version: 16.2.6
-    next-client-cookies:
-      specifier: 2.1.0
-      version: 2.1.0
-    next-intl:
-      specifier: 4.8.2
-      version: 4.8.2
     prettier:
       specifier: 3.9.6
       version: 3.9.6
-    react:
-      specifier: 19.2.6
-      version: 19.2.6
     react-day-picker:
       specifier: 9.14.0
       version: 9.14.0
-    react-dom:
-      specifier: 19.2.6
-      version: 19.2.6
     react-dropzone:
       specifier: 15.0.0
       version: 15.0.0
     react-hook-form:
       specifier: 7.71.2
       version: 7.71.2
-    reflect-metadata:
-      specifier: 0.2.2
-      version: 0.2.2
     sonner:
       specifier: 2.0.7
       version: 2.0.7
@@ -153,12 +60,6 @@ catalogs:
     turbo:
       specifier: 2.10.7
       version: 2.10.7
-    type-graphql:
-      specifier: 2.0.0-rc.2
-      version: 2.0.0-rc.2
-    typedi:
-      specifier: 0.10.0
-      version: 0.10.0
     typescript:
       specifier: 6.0.3
       version: 6.0.3
@@ -267,7 +168,7 @@ importers:
         version: 8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@29.0.2)(vite@7.3.1(@types/node@25.2.3)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)(tsx@4.22.4)(yaml@2.7.0))
+        version: 4.1.10(@types/node@25.2.3)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(vite@7.3.1(@types/node@25.2.3)(jiti@2.7.0)(lightningcss@1.32.0))
 
   apps/admin-web:
     dependencies:
@@ -578,7 +479,7 @@ importers:
         version: link:../../libs/shared/utils-structure-react
       '@sentry/nextjs':
         specifier: 'catalog:'
-        version: 10.38.0(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.97.3))(react@19.2.6)(webpack@5.98.0)
+        version: 10.38.0(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.97.3))(react@19.2.6)(webpack@5.98.0(@swc/core@1.15.11))
       date-fns:
         specifier: 3.6.0
         version: 3.6.0
@@ -10814,7 +10715,7 @@ snapshots:
   '@boundaries/elements@2.0.1(@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0))':
     dependencies:
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.1)(eslint@10.8.0(jiti@2.7.0))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint@10.8.0(jiti@2.7.0))
       handlebars: 4.7.9
       is-core-module: 2.16.1
       micromatch: 4.0.8
@@ -13451,7 +13352,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@sentry/nextjs@10.38.0(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.97.3))(react@19.2.6)(webpack@5.98.0)':
+  '@sentry/nextjs@10.38.0(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.97.3))(react@19.2.6)(webpack@5.98.0(@swc/core@1.15.11))':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.39.0
@@ -13463,7 +13364,7 @@ snapshots:
       '@sentry/opentelemetry': 10.38.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.39.0)
       '@sentry/react': 10.38.0(react@19.2.6)
       '@sentry/vercel-edge': 10.38.0
-      '@sentry/webpack-plugin': 4.9.1(encoding@0.1.13)(webpack@5.98.0)
+      '@sentry/webpack-plugin': 4.9.1(encoding@0.1.13)(webpack@5.98.0(@swc/core@1.15.11))
       next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.97.3)
       rollup: 4.57.1
       stacktrace-parser: 0.1.10
@@ -13561,12 +13462,12 @@ snapshots:
       '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
       '@sentry/core': 10.38.0
 
-  '@sentry/webpack-plugin@4.9.1(encoding@0.1.13)(webpack@5.98.0)':
+  '@sentry/webpack-plugin@4.9.1(encoding@0.1.13)(webpack@5.98.0(@swc/core@1.15.11))':
     dependencies:
       '@sentry/bundler-plugin-core': 4.9.1(encoding@0.1.13)
       unplugin: 1.0.1
       uuid: 9.0.1
-      webpack: 5.98.0
+      webpack: 5.98.0(@swc/core@1.15.11)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -14296,7 +14197,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@29.0.2)(vite@7.3.1(@types/node@25.2.3)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)(tsx@4.22.4)(yaml@2.7.0))
+      vitest: 4.1.10(@types/node@25.2.3)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(vite@7.3.1(@types/node@25.2.3)(jiti@2.7.0)(lightningcss@1.32.0))
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -14307,13 +14208,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.10(vite@7.3.1(@types/node@25.2.3)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)(tsx@4.22.4)(yaml@2.7.0))':
+  '@vitest/mocker@4.1.10(vite@7.3.1(@types/node@25.2.3)(jiti@2.7.0)(lightningcss@1.32.0))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.2.3)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)(tsx@4.22.4)(yaml@2.7.0)
+      vite: 7.3.1(@types/node@25.2.3)(jiti@2.7.0)(lightningcss@1.32.0)
 
   '@vitest/mocker@4.1.10(vite@7.3.1(@types/node@25.5.0)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)(tsx@4.22.4)(yaml@2.7.0))':
     dependencies:
@@ -14350,7 +14251,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@29.0.2)(vite@7.3.1(@types/node@25.2.3)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)(tsx@4.22.4)(yaml@2.7.0))
+      vitest: 4.1.10(@types/node@25.2.3)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(vite@7.3.1(@types/node@25.2.3)(jiti@2.7.0)(lightningcss@1.32.0))
 
   '@vitest/utils@4.1.10':
     dependencies:
@@ -15483,13 +15384,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint@10.8.0(jiti@2.7.0)):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3)
+      eslint: 10.8.0(jiti@2.7.0)
+      eslint-import-resolver-node: 0.3.9
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-plugin-boundaries@6.0.2(@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)):
     dependencies:
       '@boundaries/elements': 2.0.1(@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0))
       chalk: 4.1.2
       eslint: 10.8.0(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.1)(eslint@10.8.0(jiti@2.7.0))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint@10.8.0(jiti@2.7.0))
       handlebars: 4.7.9
       micromatch: 4.0.8
     transitivePeerDependencies:
@@ -18282,13 +18193,15 @@ snapshots:
 
   term-size@2.2.1: {}
 
-  terser-webpack-plugin@5.4.0(webpack@5.98.0):
+  terser-webpack-plugin@5.4.0(@swc/core@1.15.11)(webpack@5.98.0(@swc/core@1.15.11)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.46.0
-      webpack: 5.98.0
+      webpack: 5.98.0(@swc/core@1.15.11)
+    optionalDependencies:
+      '@swc/core': 1.15.11
 
   terser@5.46.0:
     dependencies:
@@ -18596,12 +18509,12 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite@7.3.1(@types/node@25.2.3)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)(tsx@4.22.4)(yaml@2.7.0):
+  vite@7.3.1(@types/node@25.2.3)(jiti@2.7.0)(lightningcss@1.32.0):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
-      postcss: 8.5.6
+      postcss: 8.5.23
       rollup: 4.57.1
       tinyglobby: 0.2.15
     optionalDependencies:
@@ -18609,10 +18522,6 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.7.0
       lightningcss: 1.32.0
-      sass: 1.97.3
-      terser: 5.46.0
-      tsx: 4.22.4
-      yaml: 2.7.0
 
   vite@7.3.1(@types/node@25.5.0)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)(tsx@4.22.4)(yaml@2.7.0):
     dependencies:
@@ -18631,37 +18540,6 @@ snapshots:
       terser: 5.46.0
       tsx: 4.22.4
       yaml: 2.7.0
-
-  vitest@4.1.10(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@29.0.2)(vite@7.3.1(@types/node@25.2.3)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)(tsx@4.22.4)(yaml@2.7.0)):
-    dependencies:
-      '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@7.3.1(@types/node@25.2.3)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)(tsx@4.22.4)(yaml@2.7.0))
-      '@vitest/pretty-format': 4.1.10
-      '@vitest/runner': 4.1.10
-      '@vitest/snapshot': 4.1.10
-      '@vitest/spy': 4.1.10
-      '@vitest/utils': 4.1.10
-      es-module-lexer: 2.1.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.3
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.0.2
-      tinyglobby: 0.2.15
-      tinyrainbow: 3.1.0
-      vite: 7.3.1(@types/node@25.2.3)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)(tsx@4.22.4)(yaml@2.7.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.0
-      '@types/node': 25.2.3
-      '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
-      '@vitest/ui': 4.1.10(vitest@4.1.10)
-      jsdom: 29.0.2
-    transitivePeerDependencies:
-      - msw
 
   vitest@4.1.10(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@29.0.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)(tsx@4.22.4)(yaml@2.7.0)):
     dependencies:
@@ -18691,6 +18569,35 @@ snapshots:
       '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
       '@vitest/ui': 4.1.10(vitest@4.1.10)
       jsdom: 29.0.2
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.10(@types/node@25.2.3)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(vite@7.3.1(@types/node@25.2.3)(jiti@2.7.0)(lightningcss@1.32.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@7.3.1(@types/node@25.2.3)(jiti@2.7.0)(lightningcss@1.32.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 7.3.1(@types/node@25.2.3)(jiti@2.7.0)(lightningcss@1.32.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.2.3
+      '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
+      '@vitest/ui': 4.1.10(vitest@4.1.10)
     transitivePeerDependencies:
       - msw
 
@@ -18738,7 +18645,7 @@ snapshots:
 
   webpack-virtual-modules@0.5.0: {}
 
-  webpack@5.98.0:
+  webpack@5.98.0(@swc/core@1.15.11):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -18760,7 +18667,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.4.0(webpack@5.98.0)
+      terser-webpack-plugin: 5.4.0(@swc/core@1.15.11)(webpack@5.98.0(@swc/core@1.15.11))
       watchpack: 2.5.1
       webpack-sources: 3.3.4
     transitivePeerDependencies:

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -12,8 +12,9 @@ const config: Config = {
       colors: {
         dark: {
           '000': '#ffffff',
-          100: '#e5e5e5',
-          200: '#cacaca',
+          100: '#f2f2f2',
+          150: '#e8e8e8',
+          200: '#d4d4d4',
           300: '#b0b0b0',
           400: '#959595',
           500: '#7b7b7b',
@@ -118,8 +119,8 @@ const config: Config = {
         pill: '9999px',
       },
       boxShadow: {
-        card: '0 1px 3px rgba(0, 0, 0, 0.06)',
-        'card-hover': '0 4px 12px rgba(0, 0, 0, 0.08)',
+        card: '0 1px 2px rgba(0, 0, 0, 0.04), 0 2px 8px rgba(0, 0, 0, 0.04)',
+        'card-hover': '0 8px 24px rgba(0, 0, 0, 0.08), 0 2px 6px rgba(0, 0, 0, 0.04)',
         button: '0 1px 2px rgba(0, 0, 0, 0.06)',
         hero: '0 24px 60px -24px rgba(0, 0, 0, 0.12)',
       },


### PR DESCRIPTION
## Summary
디자인 퀄리티를 개선했습니다. 특히 카드, 카테고리, 랭킹/검색 영역을 중심으로 정렬과 시각적 일관성을 다듬었습니다.

## Changes
- 랭킹 카드, 카테고리 그리드, 검색 빈 상태 디자인 개선
- 상품 카드, 요약 섹션, 상세 페이지 시각적 정렬
- MagazineInfoSection이 실제 매거진 데이터를 사용하도록 변경
- ProductAlternativePage의 서버/클라이언트 경계 문제 수정
- 로컬 개발 환경 안정화: JSON-LD hydration, Firebase emulator key, GraphQL URL fallback

## Verification
- service-web typecheck / lint 통과
- production build 성공
- 주요 페이지(홈, 랭킹, 검색, 카테고리, 상세, 대안) 실제 데이터 기반 캡처 확인