### PR TITLE
fix: 홈화면 로딩 시 width 점프 현상 수정

### DIFF
--- a/apps/service-web/app/[locale]/categories/[slug]/page.tsx
+++ b/apps/service-web/app/[locale]/categories/[slug]/page.tsx
@@ -31,7 +31,7 @@ const getCategory = cache(async (slug: string, locale: string) => {
     variables: { first: 100, locale },
   });
 
-  return data.categories.find(c => c.slug === slug) ?? null;
+  return data?.categories.find(c => c.slug === slug) ?? null;
 });
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {

--- a/apps/service-web/app/[locale]/loading.tsx
+++ b/apps/service-web/app/[locale]/loading.tsx
@@ -1,68 +1,26 @@
 import { ContentArea } from '@darun/ui';
 import { Layout } from '@darun/ui-layout';
-
-const SKELETON_ROW_KEYS = ['row-1', 'row-2', 'row-3', 'row-4'] as const;
-
-const Skeleton = ({
-  width = '100%',
-  height = '20px',
-  radius = '4px',
-}: {
-  width?: string | number;
-  height?: string | number;
-  radius?: string | number;
-}) => (
-  <div
-    aria-hidden="true"
-    className="bg-surface-100 motion-reduce:animate-none"
-    style={{
-      width: typeof width === 'number' ? `${width}px` : width,
-      height: typeof height === 'number' ? `${height}px` : height,
-      borderRadius: typeof radius === 'number' ? `${radius}px` : radius,
-      animation: 'pulse 1.5s ease-in-out infinite',
-    }}
-  />
-);
+import { CategoryNavigationSkeleton } from '@darun/products-shell/src/shells/CategoryNavigationSection/CategoryNavigationSkeleton';
+import { RecentProductSkeleton } from '@darun/products-shell/src/shells/RecentProductSection/RecentProductSkeleton';
+import { TrendingProductSkeleton } from '@darun/products-shell/src/shells/TrendingProductSection/TrendingProductSkeleton';
 
 export default function Loading() {
   return (
     <Layout>
-      <main className="mt-8 w-full gap-5" aria-busy="true" aria-live="polite" aria-label="페이지를 불러오는 중입니다">
-        <ContentArea>
-          <div className="mb-8 flex flex-col gap-4">
-            <Skeleton height={200} radius="8px" />
-            <div className="flex flex-row gap-4">
-              <Skeleton width="60%" height={24} />
-              <Skeleton width="30%" height={24} />
+      <main className="flex flex-col" aria-busy="true" aria-live="polite" aria-label="페이지를 불러오는 중입니다">
+        <section className="relative isolate overflow-hidden border-b border-dark-800 bg-dark-900">
+          <ContentArea className="relative z-10 py-14 md:py-20">
+            <div className="flex flex-col gap-5 md:max-w-2xl">
+              <div className="h-5 w-64 animate-pulse rounded bg-dark-700 motion-reduce:animate-none" />
+              <div className="h-10 w-80 animate-pulse rounded-lg bg-dark-700 motion-reduce:animate-none md:h-12" />
             </div>
-          </div>
+          </ContentArea>
+        </section>
 
-          <div className="flex flex-col gap-4">
-            {SKELETON_ROW_KEYS.map(rowKey => (
-              <div key={rowKey} className="flex w-full flex-row gap-4">
-                <Skeleton width={80} height={80} radius="8px" />
-                <div className="flex flex-1 flex-col justify-center gap-2">
-                  <Skeleton width="80%" height={20} />
-                  <Skeleton width="40%" height={16} />
-                </div>
-              </div>
-            ))}
-          </div>
-        </ContentArea>
+        <CategoryNavigationSkeleton />
+        <TrendingProductSkeleton />
+        <RecentProductSkeleton />
       </main>
-      <style>{`
-        @keyframes pulse {
-          0% { opacity: 1; }
-          50% { opacity: 0.5; }
-          100% { opacity: 1; }
-        }
-
-        @media (prefers-reduced-motion: reduce) {
-          * {
-            animation: none !important;
-          }
-        }
-      `}</style>
     </Layout>
   );
 }

--- a/apps/service-web/app/[locale]/loading.tsx
+++ b/apps/service-web/app/[locale]/loading.tsx
@@ -1,8 +1,8 @@
-import { ContentArea } from '@darun/ui';
-import { Layout } from '@darun/ui-layout';
 import { CategoryNavigationSkeleton } from '@darun/products-shell/src/shells/CategoryNavigationSection/CategoryNavigationSkeleton';
 import { RecentProductSkeleton } from '@darun/products-shell/src/shells/RecentProductSection/RecentProductSkeleton';
 import { TrendingProductSkeleton } from '@darun/products-shell/src/shells/TrendingProductSection/TrendingProductSkeleton';
+import { ContentArea } from '@darun/ui';
+import { Layout } from '@darun/ui-layout';
 
 export default function Loading() {
   return (

--- a/libs/products/shell/src/shells/CategoryNavigationSection/CategoryNavigationSkeleton.tsx
+++ b/libs/products/shell/src/shells/CategoryNavigationSection/CategoryNavigationSkeleton.tsx
@@ -1,21 +1,25 @@
+import { SectionWrapper } from '@darun/ui';
+
 export const CategoryNavigationSkeleton = () => {
   return (
-    <div data-testid="skel-category" className="flex w-full flex-col gap-6">
-      <div className="flex h-7 w-48 animate-pulse rounded-lg bg-dark-100" />
-      <div className="grid grid-cols-2 gap-3 md:grid-cols-3 xl:grid-cols-4">
-        {Array.from({ length: 6 }).map((_, i) => (
-          <div
-            key={String(i)}
-            className="flex min-h-36 flex-col justify-between rounded-card border border-dark-200 bg-white p-4 motion-reduce:animate-none sm:p-5"
-          >
-            <div className="flex h-12 w-12 animate-pulse motion-reduce:animate-none rounded-xl bg-dark-100" />
-            <div className="flex flex-col gap-1">
-              <div className="h-4 w-20 animate-pulse motion-reduce:animate-none rounded bg-dark-100" />
-              <div className="h-3 w-12 animate-pulse motion-reduce:animate-none rounded bg-dark-100" />
+    <SectionWrapper background="white" spacing="md">
+      <div data-testid="skel-category" className="flex w-full flex-col gap-6">
+        <div className="flex h-7 w-48 animate-pulse rounded-lg bg-dark-100" />
+        <div className="grid grid-cols-2 gap-3 md:grid-cols-3 xl:grid-cols-4">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div
+              key={String(i)}
+              className="flex min-h-36 flex-col justify-between rounded-card border border-dark-200 bg-white p-4 motion-reduce:animate-none sm:p-5"
+            >
+              <div className="flex h-12 w-12 animate-pulse motion-reduce:animate-none rounded-xl bg-dark-100" />
+              <div className="flex flex-col gap-1">
+                <div className="h-4 w-20 animate-pulse motion-reduce:animate-none rounded bg-dark-100" />
+                <div className="h-3 w-12 animate-pulse motion-reduce:animate-none rounded bg-dark-100" />
+              </div>
             </div>
-          </div>
-        ))}
+          ))}
+        </div>
       </div>
-    </div>
+    </SectionWrapper>
   );
 };

--- a/libs/products/shell/src/shells/RecentProductSection/RecentProductSkeleton.tsx
+++ b/libs/products/shell/src/shells/RecentProductSection/RecentProductSkeleton.tsx
@@ -1,25 +1,29 @@
+import { SectionWrapper } from '@darun/ui';
+
 export const RecentProductSkeleton = () => {
   return (
-    <div data-testid="skel-recent" className="flex w-full flex-col gap-6">
-      <div className="flex flex-col gap-2">
-        <div className="flex h-7 w-48 animate-pulse rounded-lg bg-dark-100" />
-        <div className="h-4 w-64 animate-pulse rounded bg-dark-100" />
-      </div>
-      <div className="grid grid-cols-2 gap-3 md:grid-cols-3 md:gap-4 lg:grid-cols-4">
-        {Array.from({ length: 8 }).map((_, i) => (
-          <div
-            key={String(i)}
-            className="flex h-full flex-col gap-3 rounded-card border border-dark-200 bg-white p-5 shadow-card"
-          >
-            <div className="h-14 w-14 animate-pulse rounded-xl bg-dark-100 motion-reduce:animate-none" />
-            <div className="flex flex-col gap-1">
-              <div className="h-6 w-3/4 animate-pulse rounded bg-dark-100 motion-reduce:animate-none" />
-              <div className="h-4 w-full animate-pulse rounded bg-dark-100 motion-reduce:animate-none" />
+    <SectionWrapper background="white" spacing="md">
+      <div data-testid="skel-recent" className="flex w-full flex-col gap-6">
+        <div className="flex flex-col gap-2">
+          <div className="flex h-7 w-48 animate-pulse rounded-lg bg-dark-100" />
+          <div className="h-4 w-64 animate-pulse rounded bg-dark-100" />
+        </div>
+        <div className="grid grid-cols-2 gap-3 md:grid-cols-3 md:gap-4 lg:grid-cols-4">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <div
+              key={String(i)}
+              className="flex h-full flex-col gap-3 rounded-card border border-dark-200 bg-white p-5 shadow-card"
+            >
+              <div className="h-14 w-14 animate-pulse rounded-xl bg-dark-100 motion-reduce:animate-none" />
+              <div className="flex flex-col gap-1">
+                <div className="h-6 w-3/4 animate-pulse rounded bg-dark-100 motion-reduce:animate-none" />
+                <div className="h-4 w-full animate-pulse rounded bg-dark-100 motion-reduce:animate-none" />
+              </div>
+              <div className="h-5 w-16 animate-pulse rounded-chip bg-dark-100 motion-reduce:animate-none" />
             </div>
-            <div className="h-5 w-16 animate-pulse rounded-chip bg-dark-100 motion-reduce:animate-none" />
-          </div>
-        ))}
+          ))}
+        </div>
       </div>
-    </div>
+    </SectionWrapper>
   );
 };

--- a/libs/products/shell/src/shells/TrendingProductSection/TrendingProductSkeleton.tsx
+++ b/libs/products/shell/src/shells/TrendingProductSection/TrendingProductSkeleton.tsx
@@ -1,28 +1,32 @@
+import { SectionWrapper } from '@darun/ui';
+
 export const TrendingProductSkeleton = () => {
   return (
-    <div data-testid="skel-trending" className="flex flex-col gap-6">
-      <div className="flex h-7 w-48 animate-pulse rounded-lg bg-dark-100" />
-      <div className="grid grid-cols-2 gap-3 md:grid-cols-3 md:gap-4 lg:grid-cols-4">
-        {Array.from({ length: 8 }).map((_, i) => (
-          <div
-            key={String(i)}
-            className="flex h-full flex-col gap-4 rounded-card border border-dark-200 bg-white p-5 shadow-card"
-          >
-            <div className="flex items-center gap-2.5">
-              <div className="h-3 w-2 animate-pulse rounded bg-dark-100 motion-reduce:animate-none" />
-              <div className="h-px flex-1 bg-dark-200" />
-            </div>
-            <div className="flex flex-col gap-3">
-              <div className="h-14 w-14 animate-pulse rounded-xl bg-dark-100 motion-reduce:animate-none" />
-              <div className="flex flex-col gap-1">
-                <div className="h-6 w-3/4 animate-pulse rounded bg-dark-100 motion-reduce:animate-none" />
-                <div className="h-4 w-full animate-pulse rounded bg-dark-100 motion-reduce:animate-none" />
+    <SectionWrapper background="subtle" spacing="md">
+      <div data-testid="skel-trending" className="flex w-full flex-col gap-6">
+        <div className="flex h-7 w-48 animate-pulse rounded-lg bg-dark-100" />
+        <div className="grid grid-cols-2 gap-3 md:grid-cols-3 md:gap-4 lg:grid-cols-4">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <div
+              key={String(i)}
+              className="flex h-full flex-col gap-4 rounded-card border border-dark-200 bg-white p-5 shadow-card"
+            >
+              <div className="flex items-center gap-2.5">
+                <div className="h-3 w-2 animate-pulse rounded bg-dark-100 motion-reduce:animate-none" />
+                <div className="h-px flex-1 bg-dark-200" />
               </div>
-              <div className="h-5 w-16 animate-pulse rounded-chip bg-dark-100 motion-reduce:animate-none" />
+              <div className="flex flex-col gap-3">
+                <div className="h-14 w-14 animate-pulse rounded-xl bg-dark-100 motion-reduce:animate-none" />
+                <div className="flex flex-col gap-1">
+                  <div className="h-6 w-3/4 animate-pulse rounded bg-dark-100 motion-reduce:animate-none" />
+                  <div className="h-4 w-full animate-pulse rounded bg-dark-100 motion-reduce:animate-none" />
+                </div>
+                <div className="h-5 w-16 animate-pulse rounded-chip bg-dark-100 motion-reduce:animate-none" />
+              </div>
             </div>
-          </div>
-        ))}
+          ))}
+        </div>
       </div>
-    </div>
+    </SectionWrapper>
   );
 };


### PR DESCRIPTION
## 문제

홈화면 로딩 시 Skeleton 컴포넌트들이 `SectionWrapper` 없이 렌더링되어 화면 전체 너비로 퍼지고, 로딩 완료 시 `ContentArea(max-w-1120px)`로 갑자기 좁혀지는 **width 점프 현상**이 발생했습니다.

| 섹션 | 실제 렌더링 | 수정 전 Skeleton |
|---|---|---|
| CategoryNavigation | `SectionWrapper(white, md)` → `ContentArea` | `div(flex w-full)` — 너비 제한 없음 |
| TrendingProduct | `SectionWrapper(subtle, md)` → `ContentArea` | `div(flex flex-col)` — 너비 제한, 배경 없음 |
| RecentProduct | `SectionWrapper(white, md)` → `ContentArea` | `div(flex w-full)` — 너비 제한 없음 |

또한 `loading.tsx`가 단일 `ContentArea`로 전체를 감싸고 있어, 실제 페이지의 `MainHeroBanner` full-width 다크 배경 구조와 일치하지 않았습니다.

## 변경 내용

- **`CategoryNavigationSkeleton`**: `SectionWrapper(white, md)` 추가 — 실제 섹션과 동일한 배경/간격/너비
- **`TrendingProductSkeleton`**: `SectionWrapper(subtle, md)` 추가 — 실제 섹션과 동일
- **`RecentProductSkeleton`**: `SectionWrapper(white, md)` 추가 — 실제 섹션과 동일
- **`loading.tsx`**: 실제 페이지 구조에 맞게 재작성
  - `MainHeroBanner` skeleton 추가 (`bg-dark-900`, full-width, `ContentArea` 내부)
  - 기존 단일 `ContentArea` 래퍼 제거
  - 3개 섹션 skeleton을 `SectionWrapper` 버전으로 교체
  - 커스텀 `Skeleton` 컴포넌트와 `<style>` 블록 제거 (Tailwind `animate-pulse` 사용)

## 효과

로딩 중과 완료 후의 width/배경/간격이 동일하게 유지되어, 로딩 → 콘텐츠 전환 시 시각적 점프가 사라집니다.